### PR TITLE
Ignore labels that have text_plural

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -443,6 +443,9 @@ class Validator:  # pylint: disable=too-many-lines
     def _ensure_answer_labels_and_values_match(self, answer):
         errors = []
         for option in answer.get("options", []):
+            if "text_plural" in option["label"]:
+                continue
+
             if isinstance(option["label"], str):
                 label = option["label"]
             else:


### PR DESCRIPTION
### PR Context

Currently validator attempts to check answer labels and values always match.

We shouldn't attempt to validate plurals that are used on answer labels as validator cannot resolve which string is to be used as this is based on the length of a list.
