### PR TITLE
Add max_length field to the Text Field schema

### DIFF
--- a/schemas/answers/text_field.json
+++ b/schemas/answers/text_field.json
@@ -32,6 +32,9 @@
       "visible": {
         "type": "boolean"
       },
+      "max_length": {
+        "type": "integer"
+      },
       "validation": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
### PR Context
The `max_length` variable is being added to the `text field` schema in order to support the validation of text field lengths in eq-questionnaire-runner.

### Checklist
Check that nothing is broken by this change
