### PR TITLE
Remove hard coded census date

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1878,12 +1878,20 @@ class Validator:  # pylint: disable=too-many-lines
 
         for pointer in schema_object.pointers:
             schema_text = resolve_pointer(json_schema, pointer)
-            if quote_regex.search(schema_text):
-                errors.append(
-                    self._error_message(
-                        f"Found dumb quotes(s) in schema text at {pointer}"
+            if isinstance(schema_text, dict):
+                if quote_regex.search(schema_text.get("text")):
+                    errors.append(
+                        self._error_message(
+                            f"Found dumb quotes(s) in schema text at {pointer}"
+                        )
                     )
-                )
+            else:
+                if quote_regex.search(schema_text):
+                    errors.append(
+                        self._error_message(
+                            f"Found dumb quotes(s) in schema text at {pointer}"
+                        )
+                    )
 
         return errors
 

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -15,7 +15,7 @@
           "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
         },
         "value": {
-          "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
+          "type": "string"
         },
         "q_code": {
           "$ref": "https://eq.ons.gov.uk/common_definitions.json#/q_code"

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -15,7 +15,7 @@
           "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
         },
         "value": {
-          "type": "string"
+          "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
         },
         "q_code": {
           "$ref": "https://eq.ons.gov.uk/common_definitions.json#/q_code"


### PR DESCRIPTION
### What is the context of this PR?
This change is required for schemas to work with new dynamic census date.
It fixes validation process of interstitial page content using dictionaries of placeholders and strings. 
The change is described on this trello [card](https://trello.com/c/d8k4s5QA) and requires this
[schema PR](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/19) to be merged.