### PR TITLE
Remove hard coded census date

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1878,12 +1878,20 @@ class Validator:  # pylint: disable=too-many-lines
 
         for pointer in schema_object.pointers:
             schema_text = resolve_pointer(json_schema, pointer)
-            if quote_regex.search(schema_text):
-                errors.append(
-                    self._error_message(
-                        f"Found dumb quotes(s) in schema text at {pointer}"
+            if isinstance(schema_text, dict):
+                if quote_regex.search(schema_text.get("text")):
+                    errors.append(
+                        self._error_message(
+                            f"Found dumb quotes(s) in schema text at {pointer}"
+                        )
                     )
-                )
+            else:
+                if quote_regex.search(schema_text):
+                    errors.append(
+                        self._error_message(
+                            f"Found dumb quotes(s) in schema text at {pointer}"
+                        )
+                    )
 
         return errors
 

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1878,20 +1878,17 @@ class Validator:  # pylint: disable=too-many-lines
 
         for pointer in schema_object.pointers:
             schema_text = resolve_pointer(json_schema, pointer)
-            if isinstance(schema_text, dict):
-                if quote_regex.search(schema_text.get("text")):
-                    errors.append(
-                        self._error_message(
-                            f"Found dumb quotes(s) in schema text at {pointer}"
-                        )
+            try:
+                found = quote_regex.search(schema_text.get("text"))
+            except AttributeError:
+                found = quote_regex.search(schema_text)
+
+            if found:
+                errors.append(
+                    self._error_message(
+                        f"Found dumb quotes(s) in schema text at {pointer}"
                     )
-            else:
-                if quote_regex.search(schema_text):
-                    errors.append(
-                        self._error_message(
-                            f"Found dumb quotes(s) in schema text at {pointer}"
-                        )
-                    )
+                )
 
         return errors
 

--- a/tests/schemas/valid/test_placeholder_in_contents_list.json
+++ b/tests/schemas/valid/test_placeholder_in_contents_list.json
@@ -1,0 +1,78 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "session_timeout_in_seconds": 3,
+  "title": "Test Content Variants",
+  "theme": "default",
+  "description": "A questionnaire to test content variants and variant choices",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+   "sections": [
+      {
+         "id": "section1",
+         "groups": [
+            {
+               "id": "group1",
+               "title": "",
+               "blocks": [
+                  {
+                     "content": {
+                        "contents": [
+                           {
+                              "description": "In this section, we’re going to ask you about the people living or staying at 68 Abingdon Road, Goathill."
+                           },
+                           {
+                              "list": [
+                                 "Names of the people living at this address including anyone temporarily away or who has been or intends to be in the UK for 3 months or more.",
+                                 {
+                                    "placeholders": [
+                                       {
+                                          "placeholder": "census_date",
+                                          "transforms": [
+                                             {
+                                                "arguments": {
+                                                   "date_format": "d MMMM yyyy",
+                                                   "date_to_format": {
+                                                      "value": "2021-03-21"
+                                                   }
+                                                },
+                                                "transform": "format_date"
+                                             }
+                                          ]
+                                       }
+                                    ],
+                                    "text": "Names of visitors staying overnight at this address on {census_date}"
+                                 }
+                              ],
+                              "title": "You will need to know"
+                           }
+                        ],
+                        "title": "People who live here"
+                     },
+                     "id": "who-lives-here-interstitial",
+                     "type": "Interstitial"
+                  },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_placeholder_in_contents_list.json
+++ b/tests/schemas/valid/test_placeholder_in_contents_list.json
@@ -21,51 +21,51 @@
       "type": "string"
     }
   ],
-   "sections": [
-      {
-         "id": "section1",
-         "groups": [
+  "sections": [
+    {
+      "id": "section1",
+      "groups": [
+        {
+          "id": "group1",
+          "title": "",
+          "blocks": [
             {
-               "id": "group1",
-               "title": "",
-               "blocks": [
+              "content": {
+                "contents": [
                   {
-                     "content": {
-                        "contents": [
-                           {
-                              "description": "In this section, we’re going to ask you about the people living or staying at 68 Abingdon Road, Goathill."
-                           },
-                           {
-                              "list": [
-                                 "Names of the people living at this address including anyone temporarily away or who has been or intends to be in the UK for 3 months or more.",
-                                 {
-                                    "placeholders": [
-                                       {
-                                          "placeholder": "census_date",
-                                          "transforms": [
-                                             {
-                                                "arguments": {
-                                                   "date_format": "d MMMM yyyy",
-                                                   "date_to_format": {
-                                                      "value": "2021-03-21"
-                                                   }
-                                                },
-                                                "transform": "format_date"
-                                             }
-                                          ]
-                                       }
-                                    ],
-                                    "text": "Names of visitors staying overnight at this address on {census_date}"
-                                 }
-                              ],
-                              "title": "You will need to know"
-                           }
-                        ],
-                        "title": "People who live here"
-                     },
-                     "id": "who-lives-here-interstitial",
-                     "type": "Interstitial"
+                    "description": "In this section, we’re going to ask you about the people living or staying at 68 Abingdon Road, Goathill."
                   },
+                  {
+                    "list": [
+                      "Names of the people living at this address including anyone temporarily away or who has been or intends to be in the UK for 3 months or more.",
+                      {
+                        "placeholders": [
+                          {
+                            "placeholder": "census_date",
+                            "transforms": [
+                              {
+                                "arguments": {
+                                  "date_format": "d MMMM yyyy",
+                                  "date_to_format": {
+                                    "value": "2021-03-21"
+                                  }
+                                },
+                                "transform": "format_date"
+                              }
+                            ]
+                          }
+                        ],
+                        "text": "Names of visitors staying overnight at this address on {census_date}"
+                      }
+                    ],
+                    "title": "You will need to know"
+                  }
+                ],
+                "title": "People who live here"
+              },
+              "id": "who-lives-here-interstitial",
+              "type": "Interstitial"
+            },
             {
               "type": "Summary",
               "id": "summary"

--- a/tests/schemas/valid/test_placeholder_in_contents_list.json
+++ b/tests/schemas/valid/test_placeholder_in_contents_list.json
@@ -4,9 +4,9 @@
   "data_version": "0.0.3",
   "survey_id": "0",
   "session_timeout_in_seconds": 3,
-  "title": "Test Content Variants",
+  "title": "Test List Placeholder",
   "theme": "default",
-  "description": "A questionnaire to test content variants and variant choices",
+  "description": "A questionnaire to test content list placeholders",
   "metadata": [
     {
       "name": "user_id",


### PR DESCRIPTION
### PR Context
This change adds support for validation of multiple items on a list.
Previously, it was not possible to validate contents list when one of the items was a text with a placeholder(dictionary). 
This method  adds new behaviour based on the type of data it handles. On type error it gets "text" dictionary entry from a list.
The change is described on this trello [card](https://trello.com/c/d8k4s5QA) and requires this
[schema PR](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/19) to be merged. 

