### PR TITLE
Use consistent validation references

### DIFF
--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1380,10 +1380,10 @@ class Validator:  # pylint: disable=too-many-lines
             ),
             "decimal_places": decimal_places,
             "min_referred": min_value.get("identifier")
-            if type(min_value) is dict
+            if isinstance(min_value, dict)
             else None,
             "max_referred": max_value.get("identifier")
-            if type(max_value) is dict
+            if isinstance(max_value, dict)
             else None,
             "default": answer.get("default"),
         }
@@ -1527,17 +1527,16 @@ class Validator:  # pylint: disable=too-many-lines
 
     @staticmethod
     def _get_defined_numeric_value(defined_value, system_default, answer_ranges):
-        if type(defined_value) is int:
+        if isinstance(defined_value, int):
             return defined_value
         if "source" in defined_value and defined_value["source"] == "answers":
             referred_answer = answer_ranges.get(defined_value["identifier"])
             if referred_answer is None:
                 # Referred answer is not  valid (picked up by _validate_referred_numeric_answer)
                 return None
-            elif referred_answer.get("default") is not None:
+            if referred_answer.get("default") is not None:
                 return system_default
-            else:
-                return referred_answer["min"] + referred_answer["max"]
+            return referred_answer["min"] + referred_answer["max"]
         return system_default
 
     @staticmethod
@@ -1547,8 +1546,7 @@ class Validator:  # pylint: disable=too-many-lines
         if exclusive and fallback_value:
             if min_or_max == "min":
                 return fallback_value + (1 / 10 ** decimal_places)
-            else:
-                return fallback_value - (1 / 10 ** decimal_places)
+            return fallback_value - (1 / 10 ** decimal_places)
         return fallback_value
 
     def _validate_referred_numeric_answer(self, answer, answer_ranges):
@@ -1589,13 +1587,13 @@ class Validator:  # pylint: disable=too-many-lines
         min_value = answer.get("minimum", {}).get("value", 0)
         max_value = answer.get("maximum", {}).get("value", 0)
 
-        if type(min_value) is int and min_value < MIN_NUMBER:
+        if isinstance(min_value, int) and min_value < MIN_NUMBER:
             error_message = 'Minimum value {} for answer "{}" is less than system limit of {}'.format(
                 min_value, answer["id"], MIN_NUMBER
             )
             errors.append(self._error_message(error_message))
 
-        if type(max_value) is int and max_value > MAX_NUMBER:
+        if isinstance(max_value, int) and max_value > MAX_NUMBER:
             error_message = 'Maximum value {} for answer "{}" is greater than system limit of {}'.format(
                 max_value, answer["id"], MAX_NUMBER
             )

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1302,7 +1302,12 @@ class Validator:  # pylint: disable=too-many-lines
         # Validates if a date answer has a minimum and maximum
         errors = []
 
-        if "value" in answer["minimum"] and "value" in answer["maximum"]:
+        if (
+            "value" in answer["minimum"]
+            and "value" in answer["maximum"]
+            and not isinstance(answer["minimum"]["value"], dict)
+            and not isinstance(answer["maximum"]["value"], dict)
+        ):
             minimum_date = self._get_offset_date_value(answer["minimum"])
             maximum_date = self._get_offset_date_value(answer["maximum"])
 
@@ -1527,7 +1532,7 @@ class Validator:  # pylint: disable=too-many-lines
 
     @staticmethod
     def _get_defined_numeric_value(defined_value, system_default, answer_ranges):
-        if isinstance(defined_value, int):
+        if not isinstance(defined_value, dict):
             return defined_value
         if "source" in defined_value and defined_value["source"] == "answers":
             referred_answer = answer_ranges.get(defined_value["identifier"])

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1372,6 +1372,12 @@ class Validator:  # pylint: disable=too-many-lines
     def _get_numeric_range_values(self, answer, answer_ranges):
         min_value = answer.get("minimum", {}).get("value", {})
         max_value = answer.get("maximum", {}).get("value", {})
+        min_referred = (
+            min_value.get("identifier") if isinstance(min_value, dict) else None
+        )
+        max_referred = (
+            min_value.get("identifier") if isinstance(max_value, dict) else None
+        )
 
         exclusive = answer.get("exclusive", False)
         decimal_places = answer.get("decimal_places", 0)
@@ -1384,12 +1390,8 @@ class Validator:  # pylint: disable=too-many-lines
                 max_value, decimal_places, exclusive, answer_ranges
             ),
             "decimal_places": decimal_places,
-            "min_referred": min_value.get("identifier")
-            if isinstance(min_value, dict)
-            else None,
-            "max_referred": max_value.get("identifier")
-            if isinstance(max_value, dict)
-            else None,
+            "min_referred": min_referred,
+            "max_referred": max_referred,
             "default": answer.get("default"),
         }
 

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1512,9 +1512,8 @@ class Validator:  # pylint: disable=too-many-lines
         minimum_value = self._get_defined_numeric_value(
             defined_minimum, 0, answer_ranges
         )
-        minimum_value = self._convert_numeric_value_to_exclusive(
-            minimum_value, "min", exclusive, decimal_places
-        )
+        if minimum_value:
+            return minimum_value + (1 / 10 ** decimal_places)
 
         return minimum_value
 
@@ -1524,9 +1523,8 @@ class Validator:  # pylint: disable=too-many-lines
         maximum_value = self._get_defined_numeric_value(
             defined_maximum, MAX_NUMBER, answer_ranges
         )
-        maximum_value = self._convert_numeric_value_to_exclusive(
-            maximum_value, "max", exclusive, decimal_places
-        )
+        if exclusive:
+            return maximum_value - (1 / 10 ** decimal_places)
 
         return maximum_value
 
@@ -1543,16 +1541,6 @@ class Validator:  # pylint: disable=too-many-lines
                 return system_default
             return referred_answer["min"] + referred_answer["max"]
         return system_default
-
-    @staticmethod
-    def _convert_numeric_value_to_exclusive(
-        fallback_value, min_or_max, exclusive, decimal_places
-    ):
-        if exclusive and fallback_value:
-            if min_or_max == "min":
-                return fallback_value + (1 / 10 ** decimal_places)
-            return fallback_value - (1 / 10 ** decimal_places)
-        return fallback_value
 
     def _validate_referred_numeric_answer(self, answer, answer_ranges):
         """

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1511,7 +1511,7 @@ class Validator:  # pylint: disable=too-many-lines
     def _get_answer_minimum(
         self, defined_minimum, decimal_places, exclusive, answer_ranges
     ):
-        minimum_value = self._get_defined_numeric_value(
+        minimum_value = self._get_numeric_value(
             defined_minimum, 0, answer_ranges
         )
         if exclusive:
@@ -1521,7 +1521,7 @@ class Validator:  # pylint: disable=too-many-lines
     def _get_answer_maximum(
         self, defined_maximum, decimal_places, exclusive, answer_ranges
     ):
-        maximum_value = self._get_defined_numeric_value(
+        maximum_value = self._get_numeric_value(
             defined_maximum, MAX_NUMBER, answer_ranges
         )
         if exclusive:
@@ -1529,11 +1529,11 @@ class Validator:  # pylint: disable=too-many-lines
         return maximum_value
 
     @staticmethod
-    def _get_defined_numeric_value(defined_value, system_default, answer_ranges):
-        if not isinstance(defined_value, dict):
-            return defined_value
-        if "source" in defined_value and defined_value["source"] == "answers":
-            referred_answer = answer_ranges.get(defined_value["identifier"])
+    def _get_numeric_value(value, system_default, answer_ranges):
+        if not isinstance(value, dict):
+            return value
+        if "source" in value and value["source"] == "answers":
+            referred_answer = answer_ranges.get(value["identifier"])
             if referred_answer is None:
                 # Referred answer is not valid (picked up by _validate_referred_numeric_answer)
                 return None

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1511,9 +1511,7 @@ class Validator:  # pylint: disable=too-many-lines
     def _get_answer_minimum(
         self, defined_minimum, decimal_places, exclusive, answer_ranges
     ):
-        minimum_value = self._get_numeric_value(
-            defined_minimum, 0, answer_ranges
-        )
+        minimum_value = self._get_numeric_value(defined_minimum, 0, answer_ranges)
         if exclusive:
             return minimum_value + (1 / 10 ** decimal_places)
         return minimum_value

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1376,7 +1376,7 @@ class Validator:  # pylint: disable=too-many-lines
             min_value.get("identifier") if isinstance(min_value, dict) else None
         )
         max_referred = (
-            min_value.get("identifier") if isinstance(max_value, dict) else None
+            max_value.get("identifier") if isinstance(max_value, dict) else None
         )
 
         exclusive = answer.get("exclusive", False)

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1537,7 +1537,6 @@ class Validator:  # pylint: disable=too-many-lines
                 return None
             if referred_answer.get("default") is not None:
                 return system_default
-            return referred_answer["min"] + referred_answer["max"]
         return system_default
 
     def _validate_referred_numeric_answer(self, answer, answer_ranges):

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1537,7 +1537,7 @@ class Validator:  # pylint: disable=too-many-lines
         if "source" in defined_value and defined_value["source"] == "answers":
             referred_answer = answer_ranges.get(defined_value["identifier"])
             if referred_answer is None:
-                # Referred answer is not  valid (picked up by _validate_referred_numeric_answer)
+                # Referred answer is not valid (picked up by _validate_referred_numeric_answer)
                 return None
             if referred_answer.get("default") is not None:
                 return system_default

--- a/app/validation/validator.py
+++ b/app/validation/validator.py
@@ -1512,9 +1512,8 @@ class Validator:  # pylint: disable=too-many-lines
         minimum_value = self._get_defined_numeric_value(
             defined_minimum, 0, answer_ranges
         )
-        if minimum_value:
+        if exclusive:
             return minimum_value + (1 / 10 ** decimal_places)
-
         return minimum_value
 
     def _get_answer_maximum(
@@ -1525,7 +1524,6 @@ class Validator:  # pylint: disable=too-many-lines
         )
         if exclusive:
             return maximum_value - (1 / 10 ** decimal_places)
-
         return maximum_value
 
     @staticmethod

--- a/schemas/answers/currency.json
+++ b/schemas/answers/currency.json
@@ -37,10 +37,10 @@
         "type": "integer",
         "description": "Default value if no answer given"
       },
-      "max_value": {
+      "maximum": {
         "$ref": "definitions.json#/max_value"
       },
-      "min_value": {
+      "minimum": {
         "$ref": "definitions.json#/min_value"
       },
       "currency": {

--- a/schemas/answers/date.json
+++ b/schemas/answers/date.json
@@ -47,66 +47,28 @@
         "description": "minimum offset date for user entered date to be larger than.",
         "properties": {
           "value": {
-            "type": "string",
-            "description": "date string or 'now'."
-          },
-          "answer_id": {
-            "type": "string",
-            "description": "The id of an answer from which to obtain the date"
-          },
-          "meta": {
-            "type": "string",
-            "description": "Metadata provided by the calling service. This will vary between surveys."
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/value_reference"
           },
           "offset_by": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/offset_by_yyyy_mm_dd"
           }
         },
         "additionalProperties": false,
-        "oneOf": [
-          {
-            "required": ["value"]
-          },
-          {
-            "required": ["answer_id"]
-          },
-          {
-            "required": ["meta"]
-          }
-        ]
+        "required": ["value"]
       },
       "maximum": {
         "type": "object",
         "description": "maximum offset date for user entered date to be lower than.",
         "properties": {
           "value": {
-            "type": "string",
-            "description": "date string or 'now'."
-          },
-          "answer_id": {
-            "type": "string",
-            "description": "The id of an answer from which to obtain the date"
-          },
-          "meta": {
-            "type": "string",
-            "description": "Metadata provided by the calling service. This will vary between surveys."
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/value_reference"
           },
           "offset_by": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/offset_by_yyyy_mm_dd"
           }
         },
         "additionalProperties": false,
-        "oneOf": [
-          {
-            "required": ["value"]
-          },
-          {
-            "required": ["answer_id"]
-          },
-          {
-            "required": ["meta"]
-          }
-        ]
+        "required": ["value"]
       }
     },
     "additionalProperties": false,

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -47,57 +47,31 @@
       "required": ["label", "value"]
     }
   },
-  "max_value": {
-    "type": "object",
-    "properties": {
-      "value": {
-        "type": "integer",
-        "description": "Maximum numeric value allowed."
-      },
-      "answer_id": {
-        "type": "string",
-        "description": "The id of an answer from which to obtain the max_value"
-      },
-      "exclusive": {
-        "type": "boolean",
-        "description": "Whether validation is exclusive of value or not"
-      }
-    },
-    "additionalProperties": false,
-    "oneOf": [
-      {
-        "required": ["value"]
-      },
-      {
-        "required": ["answer_id"]
-      }
-    ]
-  },
   "min_value": {
     "type": "object",
     "properties": {
       "value": {
-        "type": "integer",
-        "description": "Minimum numeric value allowed."
-      },
-      "answer_id": {
-        "type": "string",
-        "description": "The id of an answer from which to obtain the min_value"
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/value_reference"
       },
       "exclusive": {
         "type": "boolean",
         "description": "Whether validation is exclusive of value or not"
       }
     },
-    "additionalProperties": false,
-    "oneOf": [
-      {
-        "required": ["value"]
+    "additionalProperties": false
+  },
+  "max_value": {
+    "type": "object",
+    "properties": {
+      "value": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/value_reference"
       },
-      {
-        "required": ["answer_id"]
+      "exclusive": {
+        "type": "boolean",
+        "description": "Whether validation is exclusive of value or not"
       }
-    ]
+    },
+    "additionalProperties": false
   },
   "answer_guidance": {
     "description": "Answer guidance",

--- a/schemas/answers/month_year_date.json
+++ b/schemas/answers/month_year_date.json
@@ -47,16 +47,7 @@
         "description": "minimum offset date for user entered date to be larger than.",
         "properties": {
           "value": {
-            "type": "string",
-            "description": "date string or 'now'."
-          },
-          "answer_id": {
-            "type": "string",
-            "description": "The id of an answer from which to obtain the date"
-          },
-          "meta": {
-            "type": "string",
-            "description": "Metadata provided by the calling service. This will vary between surveys."
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/value_reference"
           },
           "offset_by": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/offset_by_yyyy_mm"
@@ -80,16 +71,7 @@
         "description": "maximum offset date for user entered date to be lower than.",
         "properties": {
           "value": {
-            "type": "string",
-            "description": "date string or 'now'."
-          },
-          "answer_id": {
-            "type": "string",
-            "description": "The id of an answer from which to obtain the date"
-          },
-          "meta": {
-            "type": "string",
-            "description": "Metadata provided by the calling service. This will vary between surveys."
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/value_reference"
           },
           "offset_by": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/offset_by_yyyy_mm"

--- a/schemas/answers/number.json
+++ b/schemas/answers/number.json
@@ -40,10 +40,10 @@
         "type": "integer",
         "description": "Default value if no answer given"
       },
-      "max_value": {
+      "maximum": {
         "$ref": "definitions.json#/max_value"
       },
-      "min_value": {
+      "minimum": {
         "$ref": "definitions.json#/min_value"
       },
       "validation": {

--- a/schemas/answers/percentage.json
+++ b/schemas/answers/percentage.json
@@ -37,10 +37,10 @@
         "type": "integer",
         "description": "Default value if no answer given"
       },
-      "max_value": {
+      "maximum": {
         "$ref": "definitions.json#/max_value"
       },
-      "min_value": {
+      "minimum": {
         "$ref": "definitions.json#/min_value"
       },
       "validation": {

--- a/schemas/answers/unit.json
+++ b/schemas/answers/unit.json
@@ -37,10 +37,10 @@
         "type": "integer",
         "description": "Default value if no answer given"
       },
-      "max_value": {
+      "maximum": {
         "$ref": "definitions.json#/max_value"
       },
-      "min_value": {
+      "minimum": {
         "$ref": "definitions.json#/min_value"
       },
       "unit": {

--- a/schemas/answers/year_date.json
+++ b/schemas/answers/year_date.json
@@ -47,16 +47,7 @@
         "description": "minimum offset date for user entered date to be larger than.",
         "properties": {
           "value": {
-            "type": "string",
-            "description": "date string or 'now'."
-          },
-          "answer_id": {
-            "type": "string",
-            "description": "The id of an answer from which to obtain the date"
-          },
-          "meta": {
-            "type": "string",
-            "description": "Metadata provided by the calling service. This will vary between surveys."
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/value_reference"
           },
           "offset_by": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/offset_by_yyyy"
@@ -80,16 +71,7 @@
         "description": "maximum offset date for user entered date to be lower than.",
         "properties": {
           "value": {
-            "type": "string",
-            "description": "date string or 'now'."
-          },
-          "answer_id": {
-            "type": "string",
-            "description": "The id of an answer from which to obtain the date"
-          },
-          "meta": {
-            "type": "string",
-            "description": "Metadata provided by the calling service. This will vary between surveys."
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/value_reference"
           },
           "offset_by": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/offset_by_yyyy"

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -209,6 +209,30 @@
     "additionalProperties": false,
     "required": ["years"]
   },
+  "value_reference": {
+    "oneOf": [
+      {
+        "description": "A string or integer value",
+        "type": ["integer", "string"]
+      },
+      {
+        "description": "A reference to an answer or piece of metadata",
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier",
+            "description": "The id of an answer or metadata to reference"
+          },
+          "source": {
+            "type": "string",
+            "description": "The source of the identifier to look up"
+          }
+        },
+        "required": ["identifier", "source"],
+        "additionalProperties": false
+      }
+    ]
+  },
   "routing_rules": {
     "type": "array",
     "description": "Used to direct the journey through a survey (in conjunction with navigation).",

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -13,7 +13,7 @@
   },
   "metadata_identifier": {
     "type": "string",
-    "description": "Used to identify groups, blocks, questions and answers.",
+    "description": "The id of a metadata provided by the calling service from which to obtain the value",
     "pattern": "^[a-z0-9][a-z0-9\\-_]*[a-z0-9]$"
   },
   "question_definitions": {

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -11,6 +11,11 @@
     "description": "Used to identify groups, blocks, questions and answers.",
     "pattern": "^[a-z0-9][a-z0-9\\-]*[a-z0-9]$"
   },
+  "metadata_identifier": {
+    "type": "string",
+    "description": "Used to identify groups, blocks, questions and answers.",
+    "pattern": "^[a-z0-9][a-z0-9\\-_]*[a-z0-9]$"
+  },
   "question_definitions": {
     "description": "Allows customisation of question definition title and description.",
     "type": "array",
@@ -216,16 +221,32 @@
         "type": ["integer", "string"]
       },
       {
-        "description": "A reference to an answer or piece of metadata",
+        "description": "A reference to an answer",
         "type": "object",
         "properties": {
           "identifier": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier",
-            "description": "The id of an answer or metadata to reference"
+            "description": "The id of an answer to reference"
           },
           "source": {
             "type": "string",
-            "description": "The source of the identifier to look up"
+            "enum": ["answers"]
+          }
+        },
+        "required": ["identifier", "source"],
+        "additionalProperties": false
+      },
+      {
+        "description": "A reference to a piece of metadata",
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/metadata_identifier",
+            "description": "The id of the metadata to reference"
+          },
+          "source": {
+            "type": "string",
+            "enum": ["metadata"]
           }
         },
         "required": ["identifier", "source"],

--- a/schemas/when_rule/compare_to_multiple_values.json
+++ b/schemas/when_rule/compare_to_multiple_values.json
@@ -8,7 +8,7 @@
       "$ref": "https://eq.ons.gov.uk/when_rule/definitions.json#/answer_identifier"
     },
     "meta": {
-      "$ref": "https://eq.ons.gov.uk/when_rule/definitions.json#/metadata_identifier"
+      "$ref": "https://eq.ons.gov.uk/common_definitions.json#/metadata_identifier"
     },
     "condition": {
       "enum": ["contains all", "contains any", "equals any", "not equals any"]

--- a/schemas/when_rule/compare_to_value.json
+++ b/schemas/when_rule/compare_to_value.json
@@ -8,7 +8,7 @@
       "$ref": "https://eq.ons.gov.uk/when_rule/definitions.json#/answer_identifier"
     },
     "meta": {
-      "$ref": "https://eq.ons.gov.uk/when_rule/definitions.json#/metadata_identifier"
+      "$ref": "https://eq.ons.gov.uk/common_definitions.json#/metadata_identifier"
     },
     "condition": {
       "enum": [

--- a/schemas/when_rule/definitions.json
+++ b/schemas/when_rule/definitions.json
@@ -32,10 +32,6 @@
     "type": "string",
     "description": "The id of a location attribute from which to obtain the value"
   },
-  "metadata_identifier": {
-    "type": "string",
-    "description": "The id of a metadata provided by the calling service from which to obtain the value"
-  },
   "comparison_value": {
     "type": ["string", "boolean", "integer"],
     "description": "The value to compare against"

--- a/schemas/when_rule/definitions.json
+++ b/schemas/when_rule/definitions.json
@@ -78,7 +78,7 @@
         "$ref": "#/answer_identifier"
       },
       "meta": {
-        "$ref": "#/metadata_identifier"
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/metadata_identifier"
       },
       "value": {
         "type": "string",

--- a/tests/schemas/invalid/test_invalid_decimal_places_must_be_defined_when_using_totaliser.json
+++ b/tests/schemas/invalid/test_invalid_decimal_places_must_be_defined_when_using_totaliser.json
@@ -38,7 +38,7 @@
                     "mandatory": false,
                     "q_code": "0810",
                     "type": "Percentage",
-                    "max_value": {
+                    "maximum": {
                       "value": 100
                     }
                   },
@@ -49,7 +49,7 @@
                     "mandatory": false,
                     "q_code": "0820",
                     "type": "Percentage",
-                    "max_value": {
+                    "maximum": {
                       "value": 100
                     }
                   },
@@ -61,7 +61,7 @@
                     "mandatory": false,
                     "q_code": "10002",
                     "type": "Percentage",
-                    "max_value": {
+                    "maximum": {
                       "value": 100
                     },
                     "validation": {
@@ -91,7 +91,7 @@
                     "mandatory": false,
                     "q_code": "08101",
                     "type": "Percentage",
-                    "max_value": {
+                    "maximum": {
                       "value": 100
                     }
                   },
@@ -102,7 +102,7 @@
                     "mandatory": false,
                     "q_code": "08201",
                     "type": "Percentage",
-                    "max_value": {
+                    "maximum": {
                       "value": 100
                     }
                   },
@@ -115,7 +115,7 @@
                     "q_code": "100021",
                     "type": "Percentage",
                     "decimal_places": 1,
-                    "max_value": {
+                    "maximum": {
                       "value": 100
                     },
                     "validation": {

--- a/tests/schemas/invalid/test_invalid_id_in_grouped_answers_to_calculate.json
+++ b/tests/schemas/invalid/test_invalid_id_in_grouped_answers_to_calculate.json
@@ -32,7 +32,7 @@
                     "id": "total-answer",
                     "label": "Total",
                     "mandatory": true,
-                    "max_value": {
+                    "maximum": {
                       "value": 100
                     },
                     "type": "Number"

--- a/tests/schemas/invalid/test_invalid_mm_yyyy_date_range_period.json
+++ b/tests/schemas/invalid/test_invalid_mm_yyyy_date_range_period.json
@@ -40,7 +40,10 @@
                     "label": "Period from",
                     "mandatory": true,
                     "minimum": {
-                      "meta": "ref_p_start_date",
+                      "value": {
+                        "identifier": "ref_p_start_date",
+                        "source": "metadata"
+                      },
                       "offset_by": {
                         "months": -1
                       }
@@ -52,7 +55,10 @@
                     "label": "Period to",
                     "mandatory": true,
                     "maximum": {
-                      "meta": "ref_p_end_date",
+                      "value": {
+                        "identifier": "ref_p_end_date",
+                        "source": "metadata"
+                      },
                       "offset_by": {
                         "months": 2
                       }

--- a/tests/schemas/invalid/test_invalid_numeric_answers.json
+++ b/tests/schemas/invalid/test_invalid_numeric_answers.json
@@ -50,8 +50,11 @@
                     "id": "answer-2",
                     "label": "Invalid Range",
                     "mandatory": false,
-                    "max_value": {
-                      "answer_id": "answer-1",
+                    "maximum": {
+                      "value": {
+                        "identifier": "answer-1",
+                        "source": "answers"
+                      },
                       "exclusive": true
                     },
                     "type": "Currency"
@@ -71,11 +74,17 @@
                     "id": "answer-3",
                     "label": "Invalid References",
                     "mandatory": false,
-                    "max_value": {
-                      "answer_id": "answer-5"
+                    "maximum": {
+                      "value": {
+                        "identifier": "answer-5",
+                        "source": "answers"
+                      }
                     },
-                    "min_value": {
-                      "answer_id": "answer-4"
+                    "minimum": {
+                      "value": {
+                        "identifier": "answer-4",
+                        "source": "answers"
+                      }
                     },
                     "type": "Percentage"
                   }
@@ -94,10 +103,10 @@
                     "id": "answer-4",
                     "label": "Max/Min out of system limits",
                     "mandatory": false,
-                    "max_value": {
+                    "maximum": {
                       "value": 99999999999
                     },
-                    "min_value": {
+                    "minimum": {
                       "value": -99999999999
                     },
                     "type": "Number"
@@ -137,8 +146,11 @@
                     "id": "answer-6",
                     "label": "Invalid Range",
                     "mandatory": false,
-                    "max_value": {
-                      "answer_id": "answer-1"
+                    "maximum": {
+                      "value": {
+                        "identifier": "answer-1",
+                        "source": "answers"
+                      }
                     },
                     "type": "Currency"
                   }

--- a/tests/schemas/invalid/test_invalid_yyyy_date_range_period.json
+++ b/tests/schemas/invalid/test_invalid_yyyy_date_range_period.json
@@ -40,7 +40,10 @@
                     "label": "Period from",
                     "mandatory": true,
                     "minimum": {
-                      "meta": "ref_p_start_date",
+                      "value": {
+                        "source": "metadata",
+                        "identifier": "ref_p_start_date"
+                      },
                       "offset_by": {
                         "years": -1
                       }
@@ -52,7 +55,10 @@
                     "label": "Period to",
                     "mandatory": true,
                     "maximum": {
-                      "meta": "ref_p_end_date",
+                      "value": {
+                        "source": "metadata",
+                        "identifier": "ref_p_end_date"
+                      },
                       "offset_by": {
                         "years": 2
                       }

--- a/tests/schemas/valid/test_numeric_default_with_routing.json
+++ b/tests/schemas/valid/test_numeric_default_with_routing.json
@@ -69,8 +69,11 @@
                     "id": "answer-2",
                     "label": "Invalid Range",
                     "mandatory": false,
-                    "max_value": {
-                      "answer_id": "answer-1",
+                    "maximum": {
+                      "value": {
+                        "identifier": "answer-1",
+                        "source": "answers"
+                      },
                       "exclusive": true
                     },
                     "type": "Currency"

--- a/tests/schemas/valid/test_schema_id_regex.json
+++ b/tests/schemas/valid/test_schema_id_regex.json
@@ -28,15 +28,10 @@
               "question": {
                 "answers": [
                   {
-                    "description": "Enter percentage of growth",
+                    "label": "Enter your age",
                     "id": "answer",
-                    "label": "New to the market 2012-2014",
                     "mandatory": false,
-                    "max_value": {
-                      "value": 100
-                    },
-                    "q_code": "0",
-                    "type": "Percentage"
+                    "type": "Number"
                   }
                 ],
                 "id": "question",

--- a/tests/test_questionnaire_validation.py
+++ b/tests/test_questionnaire_validation.py
@@ -83,7 +83,6 @@ def test_invalid_numeric_answers():
     filename = "schemas/invalid/test_invalid_numeric_answers.json"
 
     expected_error_messages = [
-        'Invalid range of min = 0 and max = -1.0 is possible for answer "answer-2".',
         'The referenced answer "answer-1" has a greater number of decimal places than '
         'answer "answer-2"',
         'The referenced answer "answer-4" can not be used to set the minimum of answer '


### PR DESCRIPTION
### PR Context

Update validation references to be consistent, as per definition here: https://github.com/ONSdigital/eq-questionnaire-validator/blob/master/doc/decisions/0005-use-consistent-value-references-in-validation.md
