### PR TITLE
Use the python version github action installs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          echo "::set-env name=PYTHON_VERSION::$(cat .python-version)"
       - uses: actions/setup-python@v1
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: 3.8
+      - run: |
+          echo "::set-env name=PYTHON_VERSION::$(python -c 'import platform; print(platform.python_version())')"
       - name: Install Pipenv
         run: pip install pipenv==2018.11.26
       - name: Cache virtualenv
@@ -53,11 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          echo "::set-env name=PYTHON_VERSION::$(cat .python-version)"
       - uses: actions/setup-python@v1
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: 3.8
+      - run: |
+          echo "::set-env name=PYTHON_VERSION::$(python -c 'import platform; print(platform.python_version())')"
       - name: Install pipenv
         run: pip install pipenv==2018.11.26
       - name: Cache virtualenv
@@ -84,4 +84,3 @@ jobs:
             echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             echo "Pushing with tag [$TAG]"
             docker push onsdigital/eq-questionnaire-validator:$TAG
-


### PR DESCRIPTION
### PR Context

This resolves the issue that github actions is currently installing python 3.8.2, where our local pyenv version is only able to install 3.8.1. We use the version number to inform when to update the cache, so this should prevent any future updates to the action breaking the cache.
