### PR TITLE
Add language property to schema

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -10,9 +10,13 @@
     "title",
     "sections",
     "theme",
-    "metadata"
+    "metadata",
+    "language"
   ],
   "properties": {
+    "language": {
+      "enum": ["en", "cy", "ga", "eo"]
+    },
     "messages": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/messages"
     },

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -15,7 +15,7 @@
   ],
   "properties": {
     "language": {
-      "enum": ["en", "cy", "ga", "eo"]
+      "enum": ["cy", "en", "eo", "ga"]
     },
     "messages": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/messages"

--- a/tests/schemas/invalid/test_invalid_answer_action_redirect_to_list_add_question.json
+++ b/tests/schemas/invalid/test_invalid_answer_action_redirect_to_list_add_question.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_answer_comparison_id.json
+++ b/tests/schemas/invalid/test_invalid_answer_comparison_id.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "001",

--- a/tests/schemas/invalid/test_invalid_answer_comparison_types.json
+++ b/tests/schemas/invalid/test_invalid_answer_comparison_types.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "001",

--- a/tests/schemas/invalid/test_invalid_answer_value_in_when_rule.json
+++ b/tests/schemas/invalid/test_invalid_answer_value_in_when_rule.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.2",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_calculated_summary.json
+++ b/tests/schemas/invalid/test_invalid_calculated_summary.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_date_range_period.json
+++ b/tests/schemas/invalid/test_invalid_date_range_period.json
@@ -17,6 +17,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/invalid/test_invalid_decimal_places_must_be_defined_when_using_totaliser.json
+++ b/tests/schemas/invalid/test_invalid_decimal_places_must_be_defined_when_using_totaliser.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_duplicate_ids.json
+++ b/tests/schemas/invalid/test_invalid_duplicate_ids.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json
+++ b/tests/schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_hub_and_spoke_with_summary_confirmation.json
+++ b/tests/schemas/invalid/test_invalid_hub_and_spoke_with_summary_confirmation.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_hub_section_definition.json
+++ b/tests/schemas/invalid/test_invalid_hub_section_definition.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_id_in_grouped_answers_to_calculate.json
+++ b/tests/schemas/invalid/test_invalid_id_in_grouped_answers_to_calculate.json
@@ -17,6 +17,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/invalid/test_invalid_inconsistent_default_answers_in_variants.json
+++ b/tests/schemas/invalid/test_invalid_inconsistent_default_answers_in_variants.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_inconsistent_ids_in_variants.json
+++ b/tests/schemas/invalid/test_invalid_inconsistent_ids_in_variants.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_inconsistent_types_in_variants.json
+++ b/tests/schemas/invalid/test_invalid_inconsistent_types_in_variants.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_answer_reference_ids.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_bad_sub_block_types.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_bad_sub_block_types.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_driving_question_multiple_collectors.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_driving_question_multiple_collectors.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_driving_question_multiple_driving_questions.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_driving_question_multiple_driving_questions.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_duplicate_ids_multiple_collectors.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_duplicate_ids_multiple_collectors.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_non_radio.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_add_block_answer_ids.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_with_different_answer_ids_in_add_and_edit.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_different_answer_ids_in_add_and_edit.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_with_no_add_option.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_metadata.json
+++ b/tests/schemas/invalid/test_invalid_metadata.json
@@ -57,6 +57,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/invalid/test_invalid_mismatching_answer_label_and_value.json
+++ b/tests/schemas/invalid/test_invalid_mismatching_answer_label_and_value.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "023",

--- a/tests/schemas/invalid/test_invalid_mm_yyyy_date_range_period.json
+++ b/tests/schemas/invalid/test_invalid_mm_yyyy_date_range_period.json
@@ -25,6 +25,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/invalid/test_invalid_mutually_exclusive_conditions.json
+++ b/tests/schemas/invalid/test_invalid_mutually_exclusive_conditions.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_numeric_answers.json
+++ b/tests/schemas/invalid/test_invalid_numeric_answers.json
@@ -17,6 +17,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/invalid/test_invalid_placeholder_plurals.json
+++ b/tests/schemas/invalid/test_invalid_placeholder_plurals.json
@@ -2,6 +2,7 @@
   "eq_id": "3",
   "form_type": "3",
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",

--- a/tests/schemas/invalid/test_invalid_placeholder_question_not_mandatory.json
+++ b/tests/schemas/invalid/test_invalid_placeholder_question_not_mandatory.json
@@ -2,6 +2,7 @@
   "eq_id": "3",
   "form_type": "3",
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",

--- a/tests/schemas/invalid/test_invalid_placeholder_source_ids.json
+++ b/tests/schemas/invalid/test_invalid_placeholder_source_ids.json
@@ -2,6 +2,7 @@
   "eq_id": "3",
   "form_type": "3",
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_add_block.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_add_block.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_bad_answer_id.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_bad_answer_id.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_bad_answer_value.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_bad_answer_value.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_different_answer_ids_multi_collectors.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_different_answer_ids_multi_collectors.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_primary_person_list_collector_no_radio.json
+++ b/tests/schemas/invalid/test_invalid_primary_person_list_collector_no_radio.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_quotes_in_schema_text.json
+++ b/tests/schemas/invalid/test_invalid_quotes_in_schema_text.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_relationship_list_doesnt_exist.json
+++ b/tests/schemas/invalid/test_invalid_relationship_list_doesnt_exist.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
+++ b/tests/schemas/invalid/test_invalid_relationship_multiple_answers.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
+++ b/tests/schemas/invalid/test_invalid_relationship_no_list_specified.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
+++ b/tests/schemas/invalid/test_invalid_relationship_wrong_answer_type.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_repeating_section_list_name.json
+++ b/tests/schemas/invalid/test_invalid_repeating_section_list_name.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_repeating_section_title_placeholders.json
+++ b/tests/schemas/invalid/test_invalid_repeating_section_title_placeholders.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_routing_block.json
+++ b/tests/schemas/invalid/test_invalid_routing_block.json
@@ -17,6 +17,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/invalid/test_invalid_single_date_min_max_period.json
+++ b/tests/schemas/invalid/test_invalid_single_date_min_max_period.json
@@ -17,6 +17,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/invalid/test_invalid_single_variant.json
+++ b/tests/schemas/invalid/test_invalid_single_variant.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_string_transforms.json
+++ b/tests/schemas/invalid/test_invalid_string_transforms.json
@@ -2,6 +2,7 @@
   "eq_id": "3",
   "form_type": "3",
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",

--- a/tests/schemas/invalid/test_invalid_survey_id_whitespace.json
+++ b/tests/schemas/invalid/test_invalid_survey_id_whitespace.json
@@ -26,6 +26,7 @@
       "type": "string"
     }
   ],
+  "language": "en",
   "schema_version": "0.0.1",
   "survey_id": "lms ",
   "theme": "default",

--- a/tests/schemas/invalid/test_invalid_when_comparison_list.json
+++ b/tests/schemas/invalid/test_invalid_when_comparison_list.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "001",

--- a/tests/schemas/invalid/test_invalid_when_condition_list_property.json
+++ b/tests/schemas/invalid/test_invalid_when_condition_list_property.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.2",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_when_condition_property.json
+++ b/tests/schemas/invalid/test_invalid_when_condition_property.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.2",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/invalid/test_invalid_yyyy_date_range_period.json
+++ b/tests/schemas/invalid/test_invalid_yyyy_date_range_period.json
@@ -25,6 +25,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/invalid/test_text_field_invalid_suggestions_url.json
+++ b/tests/schemas/invalid/test_text_field_invalid_suggestions_url.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "001",

--- a/tests/schemas/valid/test_answer_action_redirect_to_list_add_question.json
+++ b/tests/schemas/valid/test_answer_action_redirect_to_list_add_question.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_content_variants.json
+++ b/tests/schemas/valid/test_content_variants.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_duplicate_answer_id_for_list_collector_valid.json
+++ b/tests/schemas/valid/test_duplicate_answer_id_for_list_collector_valid.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_hub_and_spoke.json
+++ b/tests/schemas/valid/test_hub_and_spoke.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_hub_section_ids.json
+++ b/tests/schemas/valid/test_hub_section_ids.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_list_collector_driving_question.json
+++ b/tests/schemas/valid/test_list_collector_driving_question.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_list_collector_with_routing_rule.json
+++ b/tests/schemas/valid/test_list_collector_with_routing_rule.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_list_summary_on_question.json
+++ b/tests/schemas/valid/test_list_summary_on_question.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_numeric_default_with_routing.json
+++ b/tests/schemas/valid/test_numeric_default_with_routing.json
@@ -17,6 +17,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/valid/test_placeholder_in_contents_list.json
+++ b/tests/schemas/valid/test_placeholder_in_contents_list.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_placeholder_plurals.json
+++ b/tests/schemas/valid/test_placeholder_plurals.json
@@ -2,6 +2,7 @@
   "eq_id": "3",
   "form_type": "3",
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",

--- a/tests/schemas/valid/test_placeholder_source_ids.json
+++ b/tests/schemas/valid/test_placeholder_source_ids.json
@@ -2,6 +2,7 @@
   "eq_id": "3",
   "form_type": "3",
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",

--- a/tests/schemas/valid/test_placeholder_transform.json
+++ b/tests/schemas/valid/test_placeholder_transform.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_primary_person_list_collector.json
+++ b/tests/schemas/valid/test_primary_person_list_collector.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_question_variants.json
+++ b/tests/schemas/valid/test_question_variants.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_repeating_section.json
+++ b/tests/schemas/valid/test_repeating_section.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_schema_id_regex.json
+++ b/tests/schemas/valid/test_schema_id_regex.json
@@ -17,6 +17,7 @@
     }
   ],
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "sections": [
     {

--- a/tests/schemas/valid/test_section_enabled.json
+++ b/tests/schemas/valid/test_section_enabled.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_string_transforms.json
+++ b/tests/schemas/valid/test_string_transforms.json
@@ -2,6 +2,7 @@
   "eq_id": "3",
   "form_type": "3",
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",

--- a/tests/schemas/valid/test_text_field_suggestions.json
+++ b/tests/schemas/valid/test_text_field_suggestions.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "001",

--- a/tests/schemas/valid/test_valid_metadata.json
+++ b/tests/schemas/valid/test_valid_metadata.json
@@ -2,6 +2,7 @@
   "eq_id": "3",
   "form_type": "3",
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",

--- a/tests/schemas/valid/test_when_condition_property.json
+++ b/tests/schemas/valid/test_when_condition_property.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.2",
   "data_version": "0.0.3",
   "survey_id": "0",

--- a/tests/schemas/valid/test_when_location_comparison.json
+++ b/tests/schemas/valid/test_when_location_comparison.json
@@ -1,5 +1,6 @@
 {
   "mime_type": "application/json/ons/eq",
+  "language": "en",
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "001",


### PR DESCRIPTION
### PR Context
Added a new required property `language` to schemas.

A schema should define the language it is in. This will also be used by https://github.com/ONSdigital/eq-translations/pull/50
