### PR TITLE
Add rows field to textarea schema

### DIFF
--- a/schemas/answers/text_area.json
+++ b/schemas/answers/text_area.json
@@ -29,6 +29,10 @@
       "max_length": {
         "type": "integer"
       },
+      "rows": {
+        "type": "integer",
+        "minimum": 2
+      },
       "validation": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
### PR Context
The `rows` variable is being added to the `text area` schema in order to support configurable text area size in eq-questionnaire-runner.

### Checklist
Check that nothing is broken by this change

