### PR TITLE
Correct schema reference

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -196,7 +196,7 @@
                       "type": "string"
                     },
                     "title": {
-                      "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#string_with_placeholders"
+                      "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
                     },
                     "add_link_text": {
                       "type": "string"


### PR DESCRIPTION
### PR Context

AJV fails to start at the moment due a recent version update highlighting an invalid schema reference. This hasn't yet been noticed due to ajv being used as a secondary schema validation technique.

### Checklist

Manually check validation continues to work correctly in ajv version. Confirm tests pass.
