### PR TITLE
Add show on completion property to summary

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -166,7 +166,7 @@
             "properties": {
               "show_on_completion": {
                 "type": "boolean",
-                "description": "A flag to determine whether to show the section summary on completion of the section."
+                "description": "A boolean that is used to determine whether to show the section summary on completion of the section."
               },
               "collapsible": {
                 "type": "boolean"

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -164,6 +164,10 @@
           "summary": {
             "type": "object",
             "properties": {
+              "show_on_completion": {
+                "type": "boolean",
+                "description": "A flag to determine whether to show the section summary on completion of the section."
+              },
               "collapsible": {
                 "type": "boolean"
               },
@@ -194,11 +198,8 @@
                 }
               }
             },
-            "additionalProperties": false
-          },
-          "show_summary_on_completion": {
-            "type": "boolean",
-            "description": "On completion of the section a summary will be shown"
+            "additionalProperties": false,
+            "required": ["show_on_completion"]
           },
           "show_on_hub": {
             "type": "boolean",

--- a/tests/schemas/invalid/test_invalid_custom_list_summary.json
+++ b/tests/schemas/invalid/test_invalid_custom_list_summary.json
@@ -26,6 +26,7 @@
       "id": "section",
       "title": "Who Lives Here",
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json
+++ b/tests/schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json
@@ -28,7 +28,7 @@
     {
       "id": "employment-section",
       "title": "Employment",
-      "summary": {},
+      "summary": {"show_on_completion": true},
       "groups": [
         {
           "id": "radio",

--- a/tests/schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json
+++ b/tests/schemas/invalid/test_invalid_hub_and_spoke_and_summary_confirmation_non_existent.json
@@ -28,7 +28,7 @@
     {
       "id": "employment-section",
       "title": "Employment",
-      "summary": {"show_on_completion": true},
+      "summary": { "show_on_completion": true },
       "groups": [
         {
           "id": "radio",

--- a/tests/schemas/invalid/test_invalid_hub_section_definition.json
+++ b/tests/schemas/invalid/test_invalid_hub_section_definition.json
@@ -29,7 +29,7 @@
     {
       "id": "employment-section",
       "title": "Employment",
-      "summary": {},
+      "summary": {"show_on_completion": true},
       "groups": [
         {
           "id": "radio",

--- a/tests/schemas/invalid/test_invalid_hub_section_definition.json
+++ b/tests/schemas/invalid/test_invalid_hub_section_definition.json
@@ -29,7 +29,7 @@
     {
       "id": "employment-section",
       "title": "Employment",
-      "summary": {"show_on_completion": true},
+      "summary": { "show_on_completion": true },
       "groups": [
         {
           "id": "radio",

--- a/tests/schemas/invalid/test_invalid_list_collector_driving_question_multiple_driving_questions.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_driving_question_multiple_driving_questions.json
@@ -28,7 +28,7 @@
     {
       "id": "section",
       "title": "People",
-      "summary": {},
+      "summary": {"show_on_completion": true},
       "groups": [
         {
           "id": "group",

--- a/tests/schemas/invalid/test_invalid_list_collector_driving_question_multiple_driving_questions.json
+++ b/tests/schemas/invalid/test_invalid_list_collector_driving_question_multiple_driving_questions.json
@@ -28,7 +28,7 @@
     {
       "id": "section",
       "title": "People",
-      "summary": {"show_on_completion": true},
+      "summary": { "show_on_completion": true },
       "groups": [
         {
           "id": "group",

--- a/tests/schemas/valid/test_answer_action_redirect_to_list_add_question.json
+++ b/tests/schemas/valid/test_answer_action_redirect_to_list_add_question.json
@@ -25,6 +25,7 @@
     {
       "id": "section",
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/valid/test_duplicate_answer_id_for_list_collector_valid.json
+++ b/tests/schemas/valid/test_duplicate_answer_id_for_list_collector_valid.json
@@ -271,6 +271,7 @@
         }
       ],
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/valid/test_hub_and_spoke.json
+++ b/tests/schemas/valid/test_hub_and_spoke.json
@@ -165,7 +165,7 @@
     {
       "id": "accommodation-section",
       "title": "accommodation",
-      "summary": {"show_on_completion": true},
+      "summary": { "show_on_completion": true },
       "groups": [
         {
           "blocks": [

--- a/tests/schemas/valid/test_hub_and_spoke.json
+++ b/tests/schemas/valid/test_hub_and_spoke.json
@@ -165,7 +165,7 @@
     {
       "id": "accommodation-section",
       "title": "accommodation",
-      "summary": {},
+      "summary": {"show_on_completion": true},
       "groups": [
         {
           "blocks": [

--- a/tests/schemas/valid/test_hub_section_ids.json
+++ b/tests/schemas/valid/test_hub_section_ids.json
@@ -29,7 +29,7 @@
     {
       "id": "employment-section",
       "title": "Employment",
-      "summary": {},
+      "summary": {"show_on_completion": true},
       "groups": [
         {
           "id": "radio",

--- a/tests/schemas/valid/test_hub_section_ids.json
+++ b/tests/schemas/valid/test_hub_section_ids.json
@@ -29,7 +29,7 @@
     {
       "id": "employment-section",
       "title": "Employment",
-      "summary": {"show_on_completion": true},
+      "summary": { "show_on_completion": true },
       "groups": [
         {
           "id": "radio",

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -25,6 +25,7 @@
     {
       "id": "section",
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/valid/test_list_collector_driving_question.json
+++ b/tests/schemas/valid/test_list_collector_driving_question.json
@@ -29,6 +29,7 @@
       "id": "section",
       "title": "People",
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/valid/test_list_collector_with_routing_rule.json
+++ b/tests/schemas/valid/test_list_collector_with_routing_rule.json
@@ -25,6 +25,7 @@
     {
       "id": "section",
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/valid/test_list_summary_on_question.json
+++ b/tests/schemas/valid/test_list_summary_on_question.json
@@ -26,6 +26,7 @@
       "id": "section",
       "title": "Who Lives Here",
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/valid/test_relationship_collector.json
+++ b/tests/schemas/valid/test_relationship_collector.json
@@ -25,6 +25,7 @@
   "sections": [
     {
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/valid/test_repeating_section.json
+++ b/tests/schemas/valid/test_repeating_section.json
@@ -29,6 +29,7 @@
       "id": "section",
       "title": "Household",
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",

--- a/tests/schemas/valid/test_when_location_comparison.json
+++ b/tests/schemas/valid/test_when_location_comparison.json
@@ -26,6 +26,7 @@
     {
       "id": "section",
       "summary": {
+        "show_on_completion": true,
         "items": [
           {
             "type": "List",


### PR DESCRIPTION
### PR Context
Adds the `show_on_completion` property of the summary to determine whether the summary should be should when a section is complete.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
