### PR TITLE
Add optional warning property to questions

### DIFF
--- a/schemas/questions/types/calculated.json
+++ b/schemas/questions/types/calculated.json
@@ -16,6 +16,9 @@
       "description": {
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
+      "warning": {
+        "type": "string"
+      },
       "definitions": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/question_definitions"
       },

--- a/schemas/questions/types/date_range.json
+++ b/schemas/questions/types/date_range.json
@@ -19,6 +19,9 @@
       "definitions": {
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
+      "warning": {
+        "type": "string"
+      },
       "guidance": {
         "$ref": "https://eq.ons.gov.uk/questions/definitions.json#/question_guidance"
       },

--- a/schemas/questions/types/general.json
+++ b/schemas/questions/types/general.json
@@ -19,6 +19,9 @@
       "instruction": {
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
+      "warning": {
+        "type": "string"
+      },
       "definitions": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/question_definitions"
       },

--- a/schemas/questions/types/mutually_exclusive.json
+++ b/schemas/questions/types/mutually_exclusive.json
@@ -19,6 +19,9 @@
       "instruction": {
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
+      "warning": {
+        "type": "string"
+      },
       "definitions": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/question_definitions"
       },

--- a/tests/schemas/valid/test_list_collector.json
+++ b/tests/schemas/valid/test_list_collector.json
@@ -127,6 +127,7 @@
                   "id": "remove-question",
                   "type": "General",
                   "title": "Are you sure you want to remove this person?",
+                  "warning": "All of the information about this person will be deleted",
                   "answers": [
                     {
                       "id": "remove-confirmation",


### PR DESCRIPTION
### Context

Adds a new optional `warning` property to questions.

### Checklist

* [x] eq-translations updated to support any new schema keys which need translation
