### PR TITLE
Remove view submitted responses

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -95,21 +95,6 @@
         "required": ["name", "type"]
       }
     },
-    "view_submitted_response": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "description": "Whether or not answers are available after submission.",
-          "type": "boolean"
-        },
-        "duration": {
-          "description": "The amount of time in seconds submitted answers are available for.",
-          "type": "integer"
-        }
-      },
-      "required": ["enabled", "duration"],
-      "additionalProperties": false
-    },
     "variables": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
### PR Context
View submitted responses is no longer needed for Census. All test schemas have had it removed from runner, so there is no need to validated it