### PR TITLE
Add instruction to interstitial pages

### DIFF
--- a/schemas/blocks/definitions.json
+++ b/schemas/blocks/definitions.json
@@ -9,6 +9,9 @@
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders",
         "description": "The top-level heading on the page"
       },
+      "instruction": {
+        "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
+      },
       "contents": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/contents"
       }

--- a/tests/schemas/valid/test_interstitial_instruction.json
+++ b/tests/schemas/valid/test_interstitial_instruction.json
@@ -1,0 +1,106 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Interstitial Pages",
+  "theme": "default",
+  "description": "A questionnaire to demo interstitial pages.",
+  "messages": {
+    "NUMBER_TOO_LARGE": "Number is too large",
+    "NUMBER_TOO_SMALL": "Number cannot be less than zero",
+    "INVALID_NUMBER": "Please enter an integer"
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "default-section",
+      "groups": [
+        {
+          "blocks": [
+            {
+              "type": "Introduction",
+              "id": "introduction"
+            },
+            {
+              "type": "Question",
+              "id": "breakfast-block",
+              "question": {
+                "answers": [
+                  {
+                    "id": "favourite-breakfast",
+                    "label": "What is your favourite breakfast food",
+                    "mandatory": false,
+                    "q_code": "0",
+                    "type": "TextField"
+                  }
+                ],
+                "description": "",
+                "id": "favourite-breakfast-question",
+                "title": "What is your favourite breakfast food",
+                "type": "General"
+              },
+              "routing_rules": []
+            },
+            {
+              "id": "breakfast-interstitial",
+              "content": {
+                "title": "Breakfast interstitial",
+                "instruction": "Just pause for a second",
+                "contents": [
+                  {
+                    "description": "You have successfully completed the breakfast section. Next we want to know about your lunch."
+                  }
+                ]
+              },
+              "type": "Interstitial"
+            },
+            {
+              "type": "Question",
+              "id": "lunch-block",
+              "question": {
+                "answers": [
+                  {
+                    "id": "favourite-lunch",
+                    "label": "What is your favourite lunchtime food",
+                    "mandatory": false,
+                    "q_code": "0",
+                    "type": "TextField"
+                  }
+                ],
+                "description": "",
+                "id": "favourite-lunch-question",
+                "title": "",
+                "type": "General"
+              },
+              "routing_rules": []
+            },
+            {
+              "type": "Confirmation",
+              "id": "confirmation",
+              "content": {
+                "title": "Thank you for your answers, do you wish to submit"
+              }
+            }
+          ],
+          "id": "favourite-foods",
+          "title": "Favourite food"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_interstitial_instruction.json
+++ b/tests/schemas/valid/test_interstitial_instruction.json
@@ -37,33 +37,13 @@
               "id": "introduction"
             },
             {
-              "type": "Question",
-              "id": "breakfast-block",
-              "question": {
-                "answers": [
-                  {
-                    "id": "favourite-breakfast",
-                    "label": "What is your favourite breakfast food",
-                    "mandatory": false,
-                    "q_code": "0",
-                    "type": "TextField"
-                  }
-                ],
-                "description": "",
-                "id": "favourite-breakfast-question",
-                "title": "What is your favourite breakfast food",
-                "type": "General"
-              },
-              "routing_rules": []
-            },
-            {
-              "id": "breakfast-interstitial",
+              "id": "interstitial",
               "content": {
                 "title": "Breakfast interstitial",
                 "instruction": "Just pause for a second",
                 "contents": [
                   {
-                    "description": "You have successfully completed the breakfast section. Next we want to know about your lunch."
+                    "description": "Next we want to know about your lunch."
                   }
                 ]
               },


### PR DESCRIPTION
### PR Context

Adds the instruction attribute to interstitial blocks to allow runner to show instructions on interstitial pages as well as questions. 

### Checklist

* [x] eq-translations updated to support any new schema keys which need translation - https://github.com/ONSdigital/eq-translations/pull/61
