### PR TITLE
Question summary: Add support for Checkbox and Number answers

### DIFF
--- a/app/error_messages.py
+++ b/app/error_messages.py
@@ -7,7 +7,7 @@ ANSWER_REFERENCE_CANNOT_BE_USED_ON_MIN = (
 ANSWER_REFERENCE_CANNOT_BE_USED_ON_MAX = (
     "The referenced answer cannot be used to set the maximum of answer"
 )
-SUMMARY_HAS_NON_TEXTFIELD_ANSWER = (
+UNSUPPPORTED_QUESTION_SUMMARY_ANSWER_TYPE = (
     "Summary concatenation can only be used for TextField answer types"
 )
 REQUIRED_HUB_SECTION_UNDEFINED = "Required section for hub is undefined"

--- a/app/error_messages.py
+++ b/app/error_messages.py
@@ -8,7 +8,7 @@ ANSWER_REFERENCE_CANNOT_BE_USED_ON_MAX = (
     "The referenced answer cannot be used to set the maximum of answer"
 )
 UNSUPPPORTED_QUESTION_SUMMARY_ANSWER_TYPE = (
-    "Summary concatenation can only be used for TextField answer types"
+    "Unsupported answer type used for question summary concatenation"
 )
 REQUIRED_HUB_SECTION_UNDEFINED = "Required section for hub is undefined"
 VARIANTS_HAS_ONE_VARIANT = "Variants list only contains one variant"

--- a/app/validators/sections/section_validator.py
+++ b/app/validators/sections/section_validator.py
@@ -120,9 +120,13 @@ class SectionValidator(Validator):
 
                 answer_validator.validate()
 
-                if question.get("summary") and answer["type"] != "TextField":
+                if question.get("summary") and answer["type"] not in [
+                    "TextField",
+                    "Checkbox",
+                    "Number",
+                ]:
                     self.add_error(
-                        error_messages.SUMMARY_HAS_NON_TEXTFIELD_ANSWER,
+                        error_messages.UNSUPPPORTED_QUESTION_SUMMARY_ANSWER_TYPE,
                         answer_id=answer["id"],
                     )
                 self.errors += answer_validator.errors

--- a/tests/schemas/invalid/test_invalid_answer_type_for_question_summary.json
+++ b/tests/schemas/invalid/test_invalid_answer_type_for_question_summary.json
@@ -29,11 +29,11 @@
           "blocks": [
             {
               "type": "Question",
-              "id": "checkbox",
+              "id": "radio",
               "question": {
                 "answers": [
                   {
-                    "id": "checkbox-answer",
+                    "id": "radio-answer",
                     "mandatory": true,
                     "options": [
                       {
@@ -45,10 +45,10 @@
                         "value": "No"
                       }
                     ],
-                    "type": "Checkbox"
+                    "type": "Radio"
                   }
                 ],
-                "id": "checkbox-question",
+                "id": "radio-question",
                 "title": "Title",
                 "type": "General",
                 "summary": {
@@ -61,7 +61,7 @@
               "id": "summary"
             }
           ],
-          "id": "checkboxes",
+          "id": "radios",
           "title": "Title"
         }
       ]

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -422,7 +422,7 @@ def test_invalid_non_textfield_question_concatenation():
 
     expected_error_messages = [
         {
-            "message": error_messages.SUMMARY_HAS_NON_TEXTFIELD_ANSWER,
+            "message": error_messages.UNSUPPPORTED_QUESTION_SUMMARY_ANSWER_TYPE,
             "answer_id": "checkbox-answer",
             "section_id": "default-section",
         }

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -415,15 +415,15 @@ def test_invalid_quotes_in_schema():
     assert validator.errors == expected_error_messages
 
 
-def test_invalid_non_textfield_question_concatenation():
-    filename = "schemas/invalid/test_invalid_question_concatenation_non_textfield.json"
+def test_invalid_answer_type_for_question_summary_concatenation():
+    filename = "schemas/invalid/test_invalid_answer_type_for_question_summary.json"
 
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
     expected_error_messages = [
         {
             "message": error_messages.UNSUPPPORTED_QUESTION_SUMMARY_ANSWER_TYPE,
-            "answer_id": "checkbox-answer",
+            "answer_id": "radio-answer",
             "section_id": "default-section",
         }
     ]


### PR DESCRIPTION
### PR Context
Extends question summary support to Checkbox and Number answer types.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
