### PR TITLE
Format error paths as pointer strings

### DIFF
--- a/app/validators/schema_validator.py
+++ b/app/validators/schema_validator.py
@@ -41,7 +41,7 @@ class SchemaValidator(Validator):
             return {}
         except ValidationError as e:
             match = best_match([e])
-            path = "/".join([str(path_element) for path_element in e.path])
+            path = "/".join(str(path_element) for path_element in e.path)
             self.add_error(match.message, verbose=e.message, pointer=f"/{path}")
         except SchemaError as e:
             self.add_error(e)

--- a/app/validators/schema_validator.py
+++ b/app/validators/schema_validator.py
@@ -41,7 +41,7 @@ class SchemaValidator(Validator):
             return {}
         except ValidationError as e:
             match = best_match([e])
-            self.add_error(match.message, verbose=e.message, path=e.path)
+            self.add_error(match.message, verbose=e.message, path=str(e.path))
         except SchemaError as e:
             self.add_error(e)
         return self.errors

--- a/app/validators/schema_validator.py
+++ b/app/validators/schema_validator.py
@@ -41,7 +41,8 @@ class SchemaValidator(Validator):
             return {}
         except ValidationError as e:
             match = best_match([e])
-            self.add_error(match.message, verbose=e.message, path=str(e.path))
+            path = "/".join([str(path_element) for path_element in e.path])
+            self.add_error(match.message, verbose=e.message, pointer=f"/{path}")
         except SchemaError as e:
             self.add_error(e)
         return self.errors

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -88,7 +88,7 @@ def test_invalid_survey_id_whitespace():
     assert validator.errors[0]["message"] == "'lms ' does not match '^[0-9a-z]+$'"
 
 
-def test_returns_strings():
+def test_returns_pointer():
     file = "schemas/invalid/test_invalid_survey_id_whitespace.json"
     json_to_validate = _open_and_load_schema_file(file)
 
@@ -96,6 +96,4 @@ def test_returns_strings():
 
     validator.validate()
 
-    assert isinstance(validator.errors[0]["message"], str)
-    assert isinstance(validator.errors[0]["verbose"], str)
-    assert isinstance(validator.errors[0]["path"], str)
+    assert validator.errors[0]["pointer"] == '/survey_id'

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -86,3 +86,16 @@ def test_invalid_survey_id_whitespace():
     validator.validate()
 
     assert validator.errors[0]["message"] == "'lms ' does not match '^[0-9a-z]+$'"
+
+
+def test_returns_strings():
+    file = "schemas/invalid/test_invalid_survey_id_whitespace.json"
+    json_to_validate = _open_and_load_schema_file(file)
+
+    validator = SchemaValidator(json_to_validate)
+
+    validator.validate()
+
+    assert isinstance(validator.errors[0]["message"], str)
+    assert isinstance(validator.errors[0]["verbose"], str)
+    assert isinstance(validator.errors[0]["path"], str)

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -96,4 +96,4 @@ def test_returns_pointer():
 
     validator.validate()
 
-    assert validator.errors[0]["pointer"] == '/survey_id'
+    assert validator.errors[0]["pointer"] == "/survey_id"


### PR DESCRIPTION
### PR Context

Validation completely fails when errors are found in the json schema definition due to error paths being returned as deques and unable to be serialised to json. This PR casts them to strings in order for correct serialisation to occur.
