### PR TITLE
Add answer default and option value mismatch rule

### DIFF
--- a/app/validators/answers/option_answer_validator.py
+++ b/app/validators/answers/option_answer_validator.py
@@ -9,7 +9,7 @@ class OptionAnswerValidator(AnswerValidator):
     ANSWER_LABEL_VALUE_MISMATCH = "Found mismatching answer value for label"
     LIST_NAME_MISSING = "List name defined in action params does not exist"
     BLOCK_ID_MISSING = "Block id defined in action params does not exist"
-    DEFAULT_MISMATCH = "Couldn't find matching value for answer default"
+    ANSWER_DEFAULT_MISSING = "Couldn't find matching value for answer default"
 
     def __init__(self, schema_element, questionnaire_schema=None):
         super().__init__(schema_element)
@@ -85,4 +85,6 @@ class OptionAnswerValidator(AnswerValidator):
         if default_value and default_value not in [
             option["value"] for option in self.options
         ]:
-            self.add_error(self.DEFAULT_MISMATCH)
+            self.add_error(
+                self.ANSWER_DEFAULT_MISSING, default=default_value, options=self.options
+            )

--- a/app/validators/answers/option_answer_validator.py
+++ b/app/validators/answers/option_answer_validator.py
@@ -22,7 +22,7 @@ class OptionAnswerValidator(AnswerValidator):
         self.validate_duplicate_options()
         self.validate_labels_and_values_match()
         self.validate_answer_actions()
-        self.validate_default_mismatch()
+        self.validate_default_exists_in_options()
         return self.errors
 
     @cached_property
@@ -80,7 +80,7 @@ class OptionAnswerValidator(AnswerValidator):
             if block_id and block_id not in self.block_ids:
                 self.add_error(self.BLOCK_ID_MISSING, block_id=block_id)
 
-    def validate_default_mismatch(self):
+    def validate_default_exists_in_options(self):
         default_value = self.answer.get("default")
         if default_value and default_value not in [
             option["value"] for option in self.options

--- a/app/validators/answers/option_answer_validator.py
+++ b/app/validators/answers/option_answer_validator.py
@@ -9,6 +9,7 @@ class OptionAnswerValidator(AnswerValidator):
     ANSWER_LABEL_VALUE_MISMATCH = "Found mismatching answer value for label"
     LIST_NAME_MISSING = "List name defined in action params does not exist"
     BLOCK_ID_MISSING = "Block id defined in action params does not exist"
+    DEFAULT_MISMATCH = "Default mismatch"
 
     def __init__(self, schema_element, questionnaire_schema=None):
         super().__init__(schema_element)
@@ -21,6 +22,7 @@ class OptionAnswerValidator(AnswerValidator):
         self.validate_duplicate_options()
         self.validate_labels_and_values_match()
         self.validate_answer_actions()
+        self.validate_default_mismatch()
         return self.errors
 
     @cached_property
@@ -77,3 +79,11 @@ class OptionAnswerValidator(AnswerValidator):
 
             if block_id and block_id not in self.block_ids:
                 self.add_error(self.BLOCK_ID_MISSING, block_id=block_id)
+
+    def validate_default_mismatch(self):
+        if self.answer.get("default") is not None:
+            values = []
+            for option in self.options:
+                values.append(option.get("value"))
+            if self.answer.get("default") not in values:
+                self.add_error(self.DEFAULT_MISMATCH)

--- a/app/validators/answers/option_answer_validator.py
+++ b/app/validators/answers/option_answer_validator.py
@@ -85,6 +85,4 @@ class OptionAnswerValidator(AnswerValidator):
         if default_value and default_value not in [
             option["value"] for option in self.options
         ]:
-            self.add_error(
-                self.ANSWER_DEFAULT_MISSING, default=default_value, options=self.options
-            )
+            self.add_error(self.ANSWER_DEFAULT_MISSING, default_value=default_value)

--- a/app/validators/answers/option_answer_validator.py
+++ b/app/validators/answers/option_answer_validator.py
@@ -81,9 +81,8 @@ class OptionAnswerValidator(AnswerValidator):
                 self.add_error(self.BLOCK_ID_MISSING, block_id=block_id)
 
     def validate_default_mismatch(self):
-        if self.answer.get("default") is not None:
-            values = []
-            for option in self.options:
-                values.append(option.get("value"))
-            if self.answer.get("default") not in values:
-                self.add_error(self.DEFAULT_MISMATCH)
+        default_value = self.answer.get("default")
+        if default_value and default_value not in [
+            option["value"] for option in self.options
+        ]:
+            self.add_error(self.DEFAULT_MISMATCH)

--- a/app/validators/answers/option_answer_validator.py
+++ b/app/validators/answers/option_answer_validator.py
@@ -9,7 +9,7 @@ class OptionAnswerValidator(AnswerValidator):
     ANSWER_LABEL_VALUE_MISMATCH = "Found mismatching answer value for label"
     LIST_NAME_MISSING = "List name defined in action params does not exist"
     BLOCK_ID_MISSING = "Block id defined in action params does not exist"
-    DEFAULT_MISMATCH = "Default mismatch"
+    DEFAULT_MISMATCH = "Couldn't find matching value for answer default"
 
     def __init__(self, schema_element, questionnaire_schema=None):
         super().__init__(schema_element)

--- a/tests/validators/answers/test_option_answer_validator.py
+++ b/tests/validators/answers/test_option_answer_validator.py
@@ -109,8 +109,8 @@ def test_validate_default_exists_in_options():
     expected_errors = [
         {
             "message": validator.ANSWER_DEFAULT_MISSING,
+            "default_value": "Yes",
             "answer_id": "correct-answer",
-            "default": "Yes",
         }
     ]
 

--- a/tests/validators/answers/test_option_answer_validator.py
+++ b/tests/validators/answers/test_option_answer_validator.py
@@ -107,7 +107,15 @@ def test_validate_default_exists_in_options():
     validator = OptionAnswerValidator(answer)
 
     expected_errors = [
-        {"message": validator.DEFAULT_MISMATCH, "answer_id": "correct-answer"}
+        {
+            "message": validator.ANSWER_DEFAULT_MISSING,
+            "answer_id": "correct-answer",
+            "default": "Yes",
+            "options": [
+                {"label": "Yes it is", "value": "Yes it is"},
+                {"label": "No", "value": "No"},
+            ],
+        }
     ]
 
     validator.validate_default_exists_in_options()

--- a/tests/validators/answers/test_option_answer_validator.py
+++ b/tests/validators/answers/test_option_answer_validator.py
@@ -90,3 +90,29 @@ def test_invalid_answer_action():
     validator.validate()
 
     assert expected_error_messages == validator.errors
+
+
+def test_validate_default_exists_in_options():
+    answer = {
+        "type": "Radio",
+        "id": "correct-answer",
+        "mandatory": False,
+        "default": "Yes",
+        "options": [
+            {"label": "Yes it is", "value": "Yes it is"},
+            {"label": "No", "value": "No"},
+        ],
+    }
+
+    validator = OptionAnswerValidator(answer)
+
+    expected_errors = [
+        {
+            "message": validator.DEFAULT_MISMATCH,
+            "answer_id": "correct-answer",
+        },
+    ]
+
+    validator.validate_default_exists_in_options()
+
+    assert expected_errors == validator.errors

--- a/tests/validators/answers/test_option_answer_validator.py
+++ b/tests/validators/answers/test_option_answer_validator.py
@@ -107,10 +107,7 @@ def test_validate_default_exists_in_options():
     validator = OptionAnswerValidator(answer)
 
     expected_errors = [
-        {
-            "message": validator.DEFAULT_MISMATCH,
-            "answer_id": "correct-answer",
-        },
+        {"message": validator.DEFAULT_MISMATCH, "answer_id": "correct-answer"}
     ]
 
     validator.validate_default_exists_in_options()

--- a/tests/validators/answers/test_option_answer_validator.py
+++ b/tests/validators/answers/test_option_answer_validator.py
@@ -111,10 +111,6 @@ def test_validate_default_exists_in_options():
             "message": validator.ANSWER_DEFAULT_MISSING,
             "answer_id": "correct-answer",
             "default": "Yes",
-            "options": [
-                {"label": "Yes it is", "value": "Yes it is"},
-                {"label": "No", "value": "No"},
-            ],
         }
     ]
 


### PR DESCRIPTION
### PR Context
This adds new rule to answer options validator that prevents mismatching answer default and options values. This change was requested on this [Trello card](https://trello.com/c/ohpvGLAQ). It fixes a bug in census schemas where default value differs from answer option value.

