### PR TITLE
Add validation key to question types

### DIFF
--- a/schemas/questions/types/calculated.json
+++ b/schemas/questions/types/calculated.json
@@ -129,7 +129,8 @@
               "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "additionalProperties": false,
       "required": ["id", "type", "calculations", "answers", "title"]

--- a/schemas/questions/types/calculated.json
+++ b/schemas/questions/types/calculated.json
@@ -109,6 +109,28 @@
           ]
         }
       },
+      "validation": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "TOTAL_SUM_NOT_EQUALS": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            },
+            "TOTAL_SUM_NOT_LESS_THAN": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            },
+            "TOTAL_SUM_NOT_GREATER_THAN": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            },
+            "TOTAL_SUM_NOT_GREATER_THAN_OR_EQUALS": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            },
+            "TOTAL_SUM_NOT_LESS_THAN_OR_EQUALS": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            }
+          }
+        }
+      },
       "additionalProperties": false,
       "required": ["id", "type", "calculations", "answers", "title"]
     }

--- a/schemas/questions/types/date_range.json
+++ b/schemas/questions/types/date_range.json
@@ -133,7 +133,8 @@
               "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
             }
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "additionalProperties": false,

--- a/schemas/questions/types/date_range.json
+++ b/schemas/questions/types/date_range.json
@@ -118,6 +118,22 @@
             }
           ]
         }
+      },
+      "validation": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "INVALID_DATE_RANGE": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            },
+            "DATE_PERIOD_TOO_SMALL": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            },
+            "DATE_PERIOD_TOO_LARGE": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            }
+          }
+        }
       }
     },
     "additionalProperties": false,

--- a/schemas/questions/types/mutually_exclusive.json
+++ b/schemas/questions/types/mutually_exclusive.json
@@ -94,7 +94,8 @@
               "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
             }
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "additionalProperties": false,

--- a/schemas/questions/types/mutually_exclusive.json
+++ b/schemas/questions/types/mutually_exclusive.json
@@ -82,6 +82,19 @@
             }
           ]
         }
+      },
+      "validation": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "MUTUALLY_EXCLUSIVE": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            },
+            "MANDATORY_QUESTION": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+            }
+          }
+        }
       }
     },
     "additionalProperties": false,

--- a/tests/schemas/valid/test_question_validation_messages.json
+++ b/tests/schemas/valid/test_question_validation_messages.json
@@ -1,167 +1,167 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "language": "en",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.3",
-    "survey_id": "0",
-    "title": "Question Validation Test",
-    "theme": "default",
-    "description": "A questionnaire to test use of the question title in validation",
-    "metadata": [
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Question Validation Test",
+  "theme": "default",
+  "description": "A questionnaire to test use of the question title in validation",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "mutually-exclusive-checkbox-section",
+      "groups": [
         {
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
-    "sections": [
-        {
-            "id": "mutually-exclusive-checkbox-section",
-            "groups": [
-                {
-                    "blocks": [
-                        {
-                            "type": "Question",
-                            "id": "date-block",
-                            "question": {
-                                "answers": [
-                                    {
-                                        "id": "date-range-from-answer",
-                                        "label": "Period from",
-                                        "mandatory": true,
-                                        "q_code": "11",
-                                        "type": "Date"
-                                    },
-                                    {
-                                        "id": "date-range-to-answer",
-                                        "label": "Period to",
-                                        "mandatory": true,
-                                        "q_code": "12",
-                                        "type": "Date"
-                                    }
-                                ],
-                                "id": "date-range-question",
-                                "title": "Date range",
-                                "warning": "The period to date must be after the period from date",
-                                "type": "DateRange",
-                                "validation": {
-                                    "INVALID_DATE_RANGE": "The date range specified is invalid"
-                                }
-                            }
-                        }
-                    ],
-                    "id": "dates",
-                    "title": "Title"
-                },
-                {
-                    "id": "calculated-question-group",
-                    "title": "Calculated Question Group",
-                    "blocks": [
-                        {
-                            "type": "Question",
-                            "id": "breakdown-block",
-                            "question": {
-                                "id": "breakdown-question",
-                                "title": "Breakdown",
-                                "type": "Calculated",
-                                "calculations": [
-                                    {
-                                        "calculation_type": "sum",
-                                        "answer_id": "total-answer",
-                                        "answers_to_calculate": ["breakdown-1", "breakdown-2"],
-                                        "conditions": ["less than"]
-                                    }
-                                ],
-                                "answers": [
-                                    {
-                                        "id": "breakdown-1",
-                                        "label": "Breakdown 1",
-                                        "mandatory": false,
-                                        "decimal_places": 2,
-                                        "type": "Currency",
-                                        "currency": "GBP"
-                                    },
-                                    {
-                                        "id": "breakdown-2",
-                                        "label": "Breakdown 2",
-                                        "mandatory": false,
-                                        "decimal_places": 2,
-                                        "type": "Currency",
-                                        "currency": "GBP"
-                                    }
-                                ],
-                                "validation": {
-                                    "messages": {
-                                        "TOTAL_SUM_NOT_LESS_THAN": "Enter answers that add up to or are less than total answer"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "id": "mutually-exclusive-mandatory-group",
-                    "title": "Mutually Exclusive Group",
-                    "blocks": [
-                        {
-                            "type": "Question",
-                            "id": "mutually-exclusive-checkbox",
-                            "question": {
-                                "id": "mutually-exclusive-checkbox-question",
-                                "type": "MutuallyExclusive",
-                                "title": "Were you a resident at any of the following addresses?",
-                                "mandatory": true,
-                                "answers": [
-                                    {
-                                        "id": "checkbox-answer",
-                                        "label": "Select answer",
-                                        "type": "Checkbox",
-                                        "mandatory": false,
-                                        "options": [
-                                            {
-                                                "label": "7 Evelyn Street, Barry",
-                                                "value": "7 Evelyn Street, Barry"
-                                            },
-                                            {
-                                                "label": "251 Argae Lane, Barry",
-                                                "value": "251 Argae Lane, Barry"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "id": "checkbox-exclusive-answer",
-                                        "mandatory": false,
-                                        "type": "Checkbox",
-                                        "options": [
-                                            {
-                                                "label": "I prefer not to say",
-                                                "description": "Some description",
-                                                "value": "I prefer not to say"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "validation": {
-                                    "messages": {
-                                        "MANDATORY_QUESTION": "Select an answer to continue"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "type": "Summary",
-                            "id": "summary"
-                        }
-                    ]
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "date-block",
+              "question": {
+                "answers": [
+                  {
+                    "id": "date-range-from-answer",
+                    "label": "Period from",
+                    "mandatory": true,
+                    "q_code": "11",
+                    "type": "Date"
+                  },
+                  {
+                    "id": "date-range-to-answer",
+                    "label": "Period to",
+                    "mandatory": true,
+                    "q_code": "12",
+                    "type": "Date"
+                  }
+                ],
+                "id": "date-range-question",
+                "title": "Date range",
+                "warning": "The period to date must be after the period from date",
+                "type": "DateRange",
+                "validation": {
+                  "INVALID_DATE_RANGE": "The date range specified is invalid"
                 }
-            ]
+              }
+            }
+          ],
+          "id": "dates",
+          "title": "Title"
+        },
+        {
+          "id": "calculated-question-group",
+          "title": "Calculated Question Group",
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "breakdown-block",
+              "question": {
+                "id": "breakdown-question",
+                "title": "Breakdown",
+                "type": "Calculated",
+                "calculations": [
+                  {
+                    "calculation_type": "sum",
+                    "answer_id": "total-answer",
+                    "answers_to_calculate": ["breakdown-1", "breakdown-2"],
+                    "conditions": ["less than"]
+                  }
+                ],
+                "answers": [
+                  {
+                    "id": "breakdown-1",
+                    "label": "Breakdown 1",
+                    "mandatory": false,
+                    "decimal_places": 2,
+                    "type": "Currency",
+                    "currency": "GBP"
+                  },
+                  {
+                    "id": "breakdown-2",
+                    "label": "Breakdown 2",
+                    "mandatory": false,
+                    "decimal_places": 2,
+                    "type": "Currency",
+                    "currency": "GBP"
+                  }
+                ],
+                "validation": {
+                  "messages": {
+                    "TOTAL_SUM_NOT_LESS_THAN": "Enter answers that add up to or are less than total answer"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "mutually-exclusive-mandatory-group",
+          "title": "Mutually Exclusive Group",
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "mutually-exclusive-checkbox",
+              "question": {
+                "id": "mutually-exclusive-checkbox-question",
+                "type": "MutuallyExclusive",
+                "title": "Were you a resident at any of the following addresses?",
+                "mandatory": true,
+                "answers": [
+                  {
+                    "id": "checkbox-answer",
+                    "label": "Select answer",
+                    "type": "Checkbox",
+                    "mandatory": false,
+                    "options": [
+                      {
+                        "label": "7 Evelyn Street, Barry",
+                        "value": "7 Evelyn Street, Barry"
+                      },
+                      {
+                        "label": "251 Argae Lane, Barry",
+                        "value": "251 Argae Lane, Barry"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "checkbox-exclusive-answer",
+                    "mandatory": false,
+                    "type": "Checkbox",
+                    "options": [
+                      {
+                        "label": "I prefer not to say",
+                        "description": "Some description",
+                        "value": "I prefer not to say"
+                      }
+                    ]
+                  }
+                ],
+                "validation": {
+                  "messages": {
+                    "MANDATORY_QUESTION": "Select an answer to continue"
+                  }
+                }
+              }
+            },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/tests/schemas/valid/test_question_validation_messages.json
+++ b/tests/schemas/valid/test_question_validation_messages.json
@@ -36,14 +36,12 @@
                     "id": "date-range-from-answer",
                     "label": "Period from",
                     "mandatory": true,
-                    "q_code": "11",
                     "type": "Date"
                   },
                   {
                     "id": "date-range-to-answer",
                     "label": "Period to",
                     "mandatory": true,
-                    "q_code": "12",
                     "type": "Date"
                   }
                 ],
@@ -52,7 +50,9 @@
                 "warning": "The period to date must be after the period from date",
                 "type": "DateRange",
                 "validation": {
-                  "INVALID_DATE_RANGE": "The date range specified is invalid"
+                  "messages": {
+                    "INVALID_DATE_RANGE": "The date range specified is invalid"
+                  }
                 }
               }
             }

--- a/tests/schemas/valid/test_question_validation_messages.json
+++ b/tests/schemas/valid/test_question_validation_messages.json
@@ -1,0 +1,167 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Question Validation Test",
+    "theme": "default",
+    "description": "A questionnaire to test use of the question title in validation",
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "mutually-exclusive-checkbox-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "date-block",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "date-range-from-answer",
+                                        "label": "Period from",
+                                        "mandatory": true,
+                                        "q_code": "11",
+                                        "type": "Date"
+                                    },
+                                    {
+                                        "id": "date-range-to-answer",
+                                        "label": "Period to",
+                                        "mandatory": true,
+                                        "q_code": "12",
+                                        "type": "Date"
+                                    }
+                                ],
+                                "id": "date-range-question",
+                                "title": "Date range",
+                                "warning": "The period to date must be after the period from date",
+                                "type": "DateRange",
+                                "validation": {
+                                    "INVALID_DATE_RANGE": "The date range specified is invalid"
+                                }
+                            }
+                        }
+                    ],
+                    "id": "dates",
+                    "title": "Title"
+                },
+                {
+                    "id": "calculated-question-group",
+                    "title": "Calculated Question Group",
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "breakdown-block",
+                            "question": {
+                                "id": "breakdown-question",
+                                "title": "Breakdown",
+                                "type": "Calculated",
+                                "calculations": [
+                                    {
+                                        "calculation_type": "sum",
+                                        "answer_id": "total-answer",
+                                        "answers_to_calculate": ["breakdown-1", "breakdown-2"],
+                                        "conditions": ["less than"]
+                                    }
+                                ],
+                                "answers": [
+                                    {
+                                        "id": "breakdown-1",
+                                        "label": "Breakdown 1",
+                                        "mandatory": false,
+                                        "decimal_places": 2,
+                                        "type": "Currency",
+                                        "currency": "GBP"
+                                    },
+                                    {
+                                        "id": "breakdown-2",
+                                        "label": "Breakdown 2",
+                                        "mandatory": false,
+                                        "decimal_places": 2,
+                                        "type": "Currency",
+                                        "currency": "GBP"
+                                    }
+                                ],
+                                "validation": {
+                                    "messages": {
+                                        "TOTAL_SUM_NOT_LESS_THAN": "Enter answers that add up to or are less than total answer"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "mutually-exclusive-mandatory-group",
+                    "title": "Mutually Exclusive Group",
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "mutually-exclusive-checkbox",
+                            "question": {
+                                "id": "mutually-exclusive-checkbox-question",
+                                "type": "MutuallyExclusive",
+                                "title": "Were you a resident at any of the following addresses?",
+                                "mandatory": true,
+                                "answers": [
+                                    {
+                                        "id": "checkbox-answer",
+                                        "label": "Select answer",
+                                        "type": "Checkbox",
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "7 Evelyn Street, Barry",
+                                                "value": "7 Evelyn Street, Barry"
+                                            },
+                                            {
+                                                "label": "251 Argae Lane, Barry",
+                                                "value": "251 Argae Lane, Barry"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "checkbox-exclusive-answer",
+                                        "mandatory": false,
+                                        "type": "Checkbox",
+                                        "options": [
+                                            {
+                                                "label": "I prefer not to say",
+                                                "description": "Some description",
+                                                "value": "I prefer not to say"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "validation": {
+                                    "messages": {
+                                        "MANDATORY_QUESTION": "Select an answer to continue"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "Summary",
+                            "id": "summary"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### PR Context

Add the validation key to those questions that support question level validation in runner. This is to re-introduce support for survey defined validation messages.
