### PR TITLE
Update to only allow single question

### DIFF
--- a/app/validators/sections/section_validator.py
+++ b/app/validators/sections/section_validator.py
@@ -77,7 +77,7 @@ class SectionValidator(Validator):
             block_validator = get_block_validator(block, self.questionnaire_schema)
             self.errors += block_validator.validate()
 
-            self.validate_questions(block)
+            self.validate_question(block)
             self.validate_variants(block)
 
     def validate_block_is_submission(self, last_block):
@@ -94,15 +94,11 @@ class SectionValidator(Validator):
         if not is_last_block_valid and not self.questionnaire_schema.is_hub_enabled:
             self.add_error(self.UNDEFINED_SUBMISSION_PAGE)
 
-    def validate_questions(self, block_or_variant):
-        questions = block_or_variant.get("questions", [])
+    def validate_question(self, block_or_variant):
         question = block_or_variant.get("question")
         routing_rules = block_or_variant.get("routing_rules", {})
 
         if question:
-            questions.append(question)
-
-        for question in questions:
             question_validator = get_question_validator(question)
 
             self.errors += question_validator.validate()
@@ -138,7 +134,7 @@ class SectionValidator(Validator):
         all_variants = question_variants + content_variants
 
         for variant in question_variants:
-            self.validate_questions(variant)
+            self.validate_question(variant)
 
         # This is validated in json schema, but the error message is not good at the moment.
         if len(question_variants) == 1 or len(content_variants) == 1:

--- a/schemas/blocks/introduction.json
+++ b/schemas/blocks/introduction.json
@@ -41,6 +41,23 @@
           "title": {
             "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
           },
+          "questions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
+                },
+                "question": {
+                  "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
+                },
+                "contents": {
+                  "$ref": "https://eq.ons.gov.uk/common_definitions.json#/contents"
+                }
+              }
+            }
+          },
           "contents": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/contents"
           }

--- a/schemas/blocks/introduction.json
+++ b/schemas/blocks/introduction.json
@@ -41,23 +41,6 @@
           "title": {
             "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
           },
-          "questions": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
-                },
-                "question": {
-                  "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
-                },
-                "contents": {
-                  "$ref": "https://eq.ons.gov.uk/common_definitions.json#/contents"
-                }
-              }
-            }
-          },
           "contents": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/contents"
           }

--- a/schemas/questions/definitions.json
+++ b/schemas/questions/definitions.json
@@ -1,13 +1,6 @@
 {
   "$id": "https://eq.ons.gov.uk/questions/definitions.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "questions": {
-    "type": "array",
-    "minItems": 1,
-    "items": {
-      "$ref": "#/question"
-    }
-  },
   "question": {
     "oneOf": [
       {


### PR DESCRIPTION
### PR Context
This removes support for `questions` key in a `section` block from validator and jsonschema. Runner's test schemas has been checked with refactored validator rules and no instances of `questions` were found, except `questions` key in `introduction` block. This change is described on [this Trello card](https://trello.com/c/FvXjNCnc). 
### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
