### PR TITLE
Enforce block ids are globally unique

### DIFF
--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -189,6 +189,7 @@ class QuestionnaireSchema:
             - answer_ids must be duplicated across add / edit blocks on list collectors which populate the same list.
         """
         unique_ids_per_block = defaultdict(set)
+        all_block_ids = []
         non_block_ids = []
         all_ids = []
 
@@ -196,18 +197,23 @@ class QuestionnaireSchema:
             if "blocks" in path:
                 # Generate a string path and add it to the set representing the ids in that path
                 path_list = path.split(".")
+                is_block_id = len(path_list) == 6
+                if is_block_id:
+                    all_block_ids.append(value)
+                else:
+                    block_path = path_list[: path_list.index("blocks") + 2]
 
-                block_path = path_list[: path_list.index("blocks") + 2]
-
-                string_path = ".".join(block_path)
-                # Since unique_ids_per_block is a set, duplicate ids will only be recorded once within the block.
-                unique_ids_per_block[string_path].add(value)
+                    string_path = ".".join(block_path)
+                    # Since unique_ids_per_block is a set, duplicate ids will only be recorded once within the block.
+                    unique_ids_per_block[string_path].add(value)
             else:
                 non_block_ids.append(value)
 
         for block_ids in unique_ids_per_block.values():
             all_ids.extend(block_ids)
+
         all_ids.extend(non_block_ids)
+        all_ids.extend(all_block_ids)
 
         return all_ids
 

--- a/tests/schemas/invalid/test_invalid_duplicate_ids.json
+++ b/tests/schemas/invalid/test_invalid_duplicate_ids.json
@@ -115,6 +115,23 @@
               }
             },
             {
+              "type": "Question",
+              "id": "block-and-question",
+              "question": {
+                "id": "block-and-question",
+                "type": "General",
+                "title": "What is your age?",
+                "answers": [
+                  {
+                    "id": "answer-2",
+                    "label": "Your age?",
+                    "mandatory": false,
+                    "type": "Number"
+                  }
+                ]
+              }
+            },
+            {
               "type": "Summary",
               "id": "summary"
             }

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -197,6 +197,7 @@ def test_duplicate_answer_ids():
         {"message": error_messages.DUPLICATE_ID_FOUND, "id": "answer-2"},
         {"message": error_messages.DUPLICATE_ID_FOUND, "id": "question-1"},
         {"message": error_messages.DUPLICATE_ID_FOUND, "id": "block-2"},
+        {"message": error_messages.DUPLICATE_ID_FOUND, "id": "block-and-question"},
     ]
 
     assert all(


### PR DESCRIPTION
### PR Context
Fixes an issue when checking duplicate ids. At the moment, block ids are allowed to share ids with any id inside the block, i.e a block id can be same as a question id.

### How to review
Ensure block ids must be globally unique between themselves and all other ids.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
