### PR TITLE
Change suggestions_url definition to string with placeholder

### DIFF
--- a/schemas/answers/text_field.json
+++ b/schemas/answers/text_field.json
@@ -20,7 +20,7 @@
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
       "suggestions_url": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+        "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
       "type": {
         "type": "string",


### PR DESCRIPTION
### PR Context
This replaces suggestions_url strings definition with string and placeholders as it's necessary for a change in schemas repo. It's described on [this Trello card](https://trello.com/c/WSPjAC5y).

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
