### PR TITLE
Add page_title definitions

### DIFF
--- a/doc/decisions/0007-custom-page-titles.md
+++ b/doc/decisions/0007-custom-page-titles.md
@@ -2,21 +2,21 @@
 
 ## Context
 
-Page titles are currently defined in question or content blocks. There is a requirement to override the default page title with a custom title. The format of the custom title will always be one of the following:
+Page titles are currently defined in question or content block using the block title property. There is a requirement to override the default page title with a custom title. The format of the custom page title will always be one of the following:
 
 1. String with no interpolation: `"This is a page title"`
 1. String with a list item index: `"Person {index}"`
-1. String with multiple list item indices: `"Person {index} and person {index}"`
+1. String with multiple list item indices: `"Person {index} and person {index}"` (RelationshipCollector blocks only)
 
-This could be achieved with the introduction of a new transform object, one that takes a list item id and returns it's index position in a list; this approach would require significant changes to almost all Census schema block definitions. Instead, we can rely on Python's string formatting to render the index value for the list item id.
+This could be achieved with the introduction of a new transform object, one that takes a list item id and returns it's index position in a list; this approach would require significant changes to almost all Census schema block definitions. Instead, we can rely on Python's string formatting to render the index value for the list item ids.
 
 ## Proposal
 
-We will add an optional `title` property to block definitions. This property, when provided, will override any question or content page title definitions for that block. If it is ommitted, the page title will still be determined from a question or content definition depending on the block type.
+We will add an optional `page_title` property to page definitions (both block and non-block pages). This property, when provided, will override any question or content page title definitions for that page. If it is ommitted, the page title will still be determined from a question or content definition depending on the definition type. For ListCollectorAction blocks, the `page_title` property can also be defined on the ListCollectorAction
 
-Python's [string formatting](https://docs.python.org/3/library/string.html#string.Formatter.format) will be used to resolve any formatting parameters. The only formatting parameters that will be resolved are `list_item_index` and `to_list_item_index`. Note that the `to_list_item_index` will only be available for Relationship block types. If either `list_item_index` (or `to_list_item_index` where applicable) cannot be resolved, the question or content title will be used.
+Python's string formatting will be used to resolve the `list_item_index` and `to_list_item_index` parameters. Note that the `to_list_item_index` will only be available for Relationship block types. If either `list_item_index` (or `to_list_item_index` where applicable) cannot be resolved, the question or content title will be used.
 
-### Example:
+### Examples:
 
 ```json
 {
@@ -24,7 +24,7 @@ Python's [string formatting](https://docs.python.org/3/library/string.html#strin
     {
       "type": "Question",
       "id": "",
-      "title": "Question or Content block: Person {list_item_index}"
+      "page_title": "Question or Content block: Person {list_item_index}"
     }
   ]
 }
@@ -32,13 +32,43 @@ Python's [string formatting](https://docs.python.org/3/library/string.html#strin
 
 ```json
 {
-  "blocks": [
+  "blocks": {
+    "type": "RelationshipCollector",
+    "id": "relationships",
+    "page_title": "How Person {list_item_index} is related to Person {to_list_item_index}",
+    "for_list": "household"
+  }
+}
+```
+
+```json
+{
+  "content": {
+    "title": "Content"
+  },
+  "page_title": "Question or Content block: Person {list_item_index}"
+}
+```
+
+```json
+{
+  "sections": [
     {
-      "type": "Question",
-      "id": "",
-      "title": "Relationship block: Person {list_item_index} and Person {to_list_item_index}"
+      "id": "section",
+      "title": "Household",
+      "page_title": "Custom section summary page title"
     }
   ]
+}
+```
+
+```json
+{
+  "add_block": {
+    "id": "add-person",
+    "type": "ListAddQuestion",
+    "page_title": "Custom page title"
+  }
 }
 ```
 

--- a/doc/decisions/0007-custom-page-titles.md
+++ b/doc/decisions/0007-custom-page-titles.md
@@ -56,7 +56,9 @@ Python's string formatting will be used to resolve the `list_item_index` and `to
     {
       "id": "section",
       "title": "Household",
-      "page_title": "Custom section summary page title"
+      "summary": {
+        "page_title": "Custom section summary page title"
+      }
     }
   ]
 }

--- a/schemas/blocks/answer_summary.json
+++ b/schemas/blocks/answer_summary.json
@@ -10,6 +10,9 @@
       "title": {
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
       "type": {
         "type": "string",
         "enum": ["AnswerSummary"]

--- a/schemas/blocks/calculated_summary.json
+++ b/schemas/blocks/calculated_summary.json
@@ -14,6 +14,9 @@
       "title": {
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
       "routing_rules": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/routing_rules"
       },

--- a/schemas/blocks/confirmation.json
+++ b/schemas/blocks/confirmation.json
@@ -7,6 +7,9 @@
       "id": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
       "number": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },

--- a/schemas/blocks/confirmation_question.json
+++ b/schemas/blocks/confirmation_question.json
@@ -7,6 +7,9 @@
       "id": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
       "number": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },

--- a/schemas/blocks/interstitial.json
+++ b/schemas/blocks/interstitial.json
@@ -12,7 +12,6 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used on the interstitial page."
       },
       "type": {
         "type": "string",

--- a/schemas/blocks/interstitial.json
+++ b/schemas/blocks/interstitial.json
@@ -12,7 +12,7 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used the interstitial page."
+        "description": "Custom page title used on the interstitial page."
       },
       "type": {
         "type": "string",

--- a/schemas/blocks/interstitial.json
+++ b/schemas/blocks/interstitial.json
@@ -11,7 +11,7 @@
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
       "page_title": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
       "type": {
         "type": "string",

--- a/schemas/blocks/interstitial.json
+++ b/schemas/blocks/interstitial.json
@@ -10,6 +10,10 @@
       "number": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "description": "Custom page title used the interstitial page."
+      },
       "type": {
         "type": "string",
         "enum": ["Interstitial"]

--- a/schemas/blocks/introduction.json
+++ b/schemas/blocks/introduction.json
@@ -10,6 +10,9 @@
       "title": {
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
       "type": {
         "type": "string",
         "enum": ["Introduction"]

--- a/schemas/blocks/list_add_edit_remove_question.json
+++ b/schemas/blocks/list_add_edit_remove_question.json
@@ -7,6 +7,10 @@
       "id": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "description": "Custom page title used for list collector action page."
+      },
       "cancel_text": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },

--- a/schemas/blocks/list_add_edit_remove_question.json
+++ b/schemas/blocks/list_add_edit_remove_question.json
@@ -9,7 +9,7 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used for list collector action page."
+        "description": "Custom page title used for list collector action pages."
       },
       "cancel_text": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/blocks/list_add_edit_remove_question.json
+++ b/schemas/blocks/list_add_edit_remove_question.json
@@ -8,7 +8,7 @@
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
       },
       "page_title": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
       "cancel_text": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/blocks/list_add_edit_remove_question.json
+++ b/schemas/blocks/list_add_edit_remove_question.json
@@ -9,7 +9,6 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used for list collector action pages."
       },
       "cancel_text": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -54,7 +54,14 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "for_list", "add_block", "edit_block", "remove_block"],
+    "required": [
+      "id",
+      "type",
+      "for_list",
+      "add_block",
+      "edit_block",
+      "remove_block"
+    ],
     "oneOf": [
       {
         "required": ["question"]

--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -25,7 +25,7 @@
         "enum": ["ListCollector"]
       },
       "page_title": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -24,6 +24,10 @@
         "type": "string",
         "enum": ["ListCollector"]
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "description": "Custom page title used for the list collector page."
+      },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
@@ -50,14 +54,7 @@
       }
     },
     "additionalProperties": false,
-    "required": [
-      "id",
-      "type",
-      "for_list",
-      "add_block",
-      "edit_block",
-      "remove_block"
-    ],
+    "required": ["id", "type", "for_list", "add_block", "edit_block", "remove_block"],
     "oneOf": [
       {
         "required": ["question"]

--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -26,7 +26,7 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used for the list collector page."
+        "description": "Custom page title used for list collector pages."
       },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
@@ -54,14 +54,7 @@
       }
     },
     "additionalProperties": false,
-    "required": [
-      "id",
-      "type",
-      "for_list",
-      "add_block",
-      "edit_block",
-      "remove_block"
-    ],
+    "required": ["id", "type", "for_list", "add_block", "edit_block", "remove_block"],
     "oneOf": [
       {
         "required": ["question"]

--- a/schemas/blocks/list_collector.json
+++ b/schemas/blocks/list_collector.json
@@ -26,7 +26,6 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used for list collector pages."
       },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/blocks/primary_person_list_collector.json
+++ b/schemas/blocks/primary_person_list_collector.json
@@ -11,6 +11,9 @@
         "type": "string",
         "enum": ["PrimaryPersonListCollector"]
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },

--- a/schemas/blocks/question.json
+++ b/schemas/blocks/question.json
@@ -12,7 +12,6 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used for the Question page."
       },
       "type": {
         "type": "string",

--- a/schemas/blocks/question.json
+++ b/schemas/blocks/question.json
@@ -10,6 +10,10 @@
       "number": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "description": "Custom page title used for the Question page."
+      },
       "type": {
         "type": "string",
         "enum": ["Question"]

--- a/schemas/blocks/question.json
+++ b/schemas/blocks/question.json
@@ -11,7 +11,7 @@
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
       "page_title": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
       "type": {
         "type": "string",

--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -16,7 +16,7 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used for the relationship collector pages."
+        "description": "Custom page title used for relationship collector pages."
       },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -14,6 +14,10 @@
       "title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "description": "Custom page title used for the relationship collector pages."
+      },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },

--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -15,7 +15,7 @@
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
       "page_title": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -16,7 +16,6 @@
       },
       "page_title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-        "description": "Custom page title used for relationship collector pages."
       },
       "for_list": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -155,10 +155,6 @@
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
             "description": "Title used for the navigation container."
           },
-          "page_title": {
-            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-            "description": "Custom Page Title used for section summary pages."
-          },
           "title_from_answers": {
             "type": "array",
             "description": "Takes a list of answer ids. Title will be generated from answer values concatenated together with spaces."
@@ -214,6 +210,9 @@
               },
               "title": {
                 "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
+              },
+              "page_title": {
+                "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
               }
             },
             "additionalProperties": false,

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -157,7 +157,7 @@
           },
           "page_title": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-            "description": "Custom Page Title used for the section summary."
+            "description": "Custom Page Title used for section summary pages."
           },
           "title_from_answers": {
             "type": "array",

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -155,6 +155,10 @@
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
             "description": "Title used for the navigation container."
           },
+          "page_title": {
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+            "description": "Custom Page Title used for the section summary."
+          },
           "title_from_answers": {
             "type": "array",
             "description": "Takes a list of answer ids. Title will be generated from answer values concatenated together with spaces."


### PR DESCRIPTION
### PR Context
- Updates decision 0007 to take into account non-block page titles and adds additional examples
- Adds the page title property to relevant definitions

### Checklist

* [x] eq-translations updated to support any new schema keys which need translation
	- https://github.com/ONSdigital/eq-translations/pull/64