### PR TITLE
Add missing page title fields to schemas

### DIFF
--- a/schemas/blocks/list_collector_driving_question.json
+++ b/schemas/blocks/list_collector_driving_question.json
@@ -7,6 +7,9 @@
       "id": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
       },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
       "number": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },

--- a/schemas/blocks/primary_person_list_collector.json
+++ b/schemas/blocks/primary_person_list_collector.json
@@ -35,6 +35,9 @@
           "id": {
             "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
           },
+          "page_title": {
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+          },
           "type": {
             "type": "string",
             "enum": ["PrimaryPersonListAddOrEditQuestion"]


### PR DESCRIPTION
### PR Context

This PR has been raised to add the missing `page_title` fields from the `list-collector-driving-question` schema and the `add-or-edit-block` within the `primary-person-list-collector` schema.

This is required in order to support the requested page title changes for the Census household schemas in this [PR](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/160)

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
