### PR TITLE
Add lookup options to address answer type

### DIFF
--- a/schemas/answers/address.json
+++ b/schemas/answers/address.json
@@ -29,6 +29,26 @@
             }
           }
         }
+      },
+      "lookup_options": {
+        "type": "object",
+        "properties": {
+          "address_type": {
+            "type": "string",
+            "enum": ["Educational", "Residential", "Workplace"]
+          },
+          "one_year_ago": {
+            "type": "boolean",
+            "description": "Setting this to true will search the address index as of one year ago. If omitted, the latest index will be searched."
+          },
+          "region_code": {
+            "type": "string",
+            "enum": ["GB-ENG", "GB-WLS", "GB-NIR"],
+            "description": "Which region to search for addresses in."
+          }
+        },
+        "additionalProperties": false,
+        "required": ["address_type", "region_code"]
       }
     },
     "additionalProperties": false,


### PR DESCRIPTION
### PR Context

Adds lookup options to the address answer type. This can be used to enable address lookups with some properties to control how the address index api does the searches.

The original idea was to use the region code from metadata, rather than a lookup option. I decided to do it as a lookup option for a number of reasons: 
- There is no guarantee of region code in the metadata for any given schema 
- The region code from metadata may not be one supported by the address index
- Setting it per answer allows a different region to be used than the schema region
- All lookup options come from the same place

### Checklist

* [-] eq-translations updated to support any new schema keys which need translation
