### PR TITLE
Add initial support for unrelated relationship block

### DIFF
--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -27,7 +27,7 @@
       "question_variants": {
         "$ref": "definitions.json#/question_variants"
       },
-      "unrelated_relationship_block": {
+      "unrelated_block": {
         "$ref": "https://eq.ons.gov.uk/blocks/unrelated_relationship_block.json#/block"
       },
       "routing_rules": {

--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -28,7 +28,7 @@
         "$ref": "definitions.json#/question_variants"
       },
       "unrelated_block": {
-        "$ref": "https://eq.ons.gov.uk/blocks/unrelated_relationship_block.json#/block"
+        "$ref": "https://eq.ons.gov.uk/blocks/unrelated_question.json#/block"
       },
       "routing_rules": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/routing_rules"

--- a/schemas/blocks/relationship_collector.json
+++ b/schemas/blocks/relationship_collector.json
@@ -5,7 +5,8 @@
     "type": "object",
     "properties": {
       "id": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
+        "type": "string",
+        "enum": ["relationships"]
       },
       "type": {
         "type": "string",
@@ -25,6 +26,9 @@
       },
       "question_variants": {
         "$ref": "definitions.json#/question_variants"
+      },
+      "unrelated_relationship_block": {
+        "$ref": "https://eq.ons.gov.uk/blocks/unrelated_relationship_block.json#/block"
       },
       "routing_rules": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/routing_rules"

--- a/schemas/blocks/unrelated_question.json
+++ b/schemas/blocks/unrelated_question.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://eq.ons.gov.uk/blocks/unrelated_relationship_block.json",
+  "$id": "https://eq.ons.gov.uk/blocks/unrelated_question.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "block": {
     "type": "object",

--- a/schemas/blocks/unrelated_relationship_block.json
+++ b/schemas/blocks/unrelated_relationship_block.json
@@ -9,7 +9,7 @@
       },
       "type": {
         "type": "string",
-        "enum": ["UnrelatedRelationship"]
+        "enum": ["UnrelatedQuestion"]
       },
       "title": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/blocks/unrelated_relationship_block.json
+++ b/schemas/blocks/unrelated_relationship_block.json
@@ -1,0 +1,41 @@
+{
+  "$id": "https://eq.ons.gov.uk/blocks/unrelated_relationship_block.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "block": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
+      },
+      "type": {
+        "type": "string",
+        "enum": ["UnrelatedRelationship"]
+      },
+      "title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
+      "page_title": {
+        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      },
+      "list_summary": {
+        "$ref": "https://eq.ons.gov.uk/blocks/definitions.json#/list_summary"
+      },
+      "question": {
+        "$ref": "https://eq.ons.gov.uk/questions/definitions.json#/question"
+      },
+      "question_variants": {
+        "$ref": "https://eq.ons.gov.uk/blocks/definitions.json#/question_variants"
+      }
+    },
+    "additionalProperties": false,
+    "required": ["id", "type", "list_summary"],
+    "oneOf": [
+      {
+        "required": ["question"]
+      },
+      {
+        "required": ["question_variants"]
+      }
+    ]
+  }
+}

--- a/tests/schemas/valid/test_relationships_unrelated.json
+++ b/tests/schemas/valid/test_relationships_unrelated.json
@@ -1,0 +1,598 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Test Relationships Unrelated Question",
+    "theme": "default",
+    "description": "A questionnaire to test capturing of relationships.",
+    "messages": {},
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "section",
+            "summary": {
+                "show_on_completion": true,
+                "items": [
+                    {
+                        "add_link_text": "Add someone to this household",
+                        "empty_list_text": "There are no householders",
+                        "for_list": "people",
+                        "title": "Household members",
+                        "type": "List"
+                    }
+                ]
+            },
+            "groups": [
+                {
+                    "id": "group",
+                    "title": "Relationships",
+                    "blocks": [
+                        {
+                            "id": "list-collector",
+                            "type": "ListCollector",
+                            "for_list": "people",
+                            "question": {
+                                "id": "confirmation-question",
+                                "type": "General",
+                                "title": "Does anyone else live at 1 Pleasant Lane?",
+                                "answers": [
+                                    {
+                                        "id": "anyone-else",
+                                        "mandatory": true,
+                                        "type": "Radio",
+                                        "options": [
+                                            {
+                                                "label": "Yes",
+                                                "value": "Yes",
+                                                "action": {
+                                                    "type": "RedirectToListAddBlock"
+                                                }
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "add_block": {
+                                "id": "add-person",
+                                "type": "ListAddQuestion",
+                                "question": {
+                                    "id": "add-question",
+                                    "type": "General",
+                                    "title": "What is the name of the person who isn’t you?",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "edit_block": {
+                                "id": "edit-person",
+                                "type": "ListEditQuestion",
+                                "question": {
+                                    "id": "edit-question",
+                                    "type": "General",
+                                    "title": "What is the name of the person?",
+                                    "answers": [
+                                        {
+                                            "id": "first-name",
+                                            "label": "First name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        },
+                                        {
+                                            "id": "last-name",
+                                            "label": "Last name",
+                                            "mandatory": true,
+                                            "type": "TextField"
+                                        }
+                                    ]
+                                }
+                            },
+                            "remove_block": {
+                                "id": "remove-person",
+                                "type": "ListRemoveQuestion",
+                                "question": {
+                                    "id": "remove-question",
+                                    "type": "General",
+                                    "title": "Are you sure you want to remove this person?",
+                                    "answers": [
+                                        {
+                                            "id": "remove-confirmation",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes",
+                                                    "action": {
+                                                        "type": "RemoveListItemAndAnswers"
+                                                    }
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "summary": {
+                                "title": "People who live here",
+                                "item_title": {
+                                    "text": "{person_name}",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "person_name",
+                                            "transforms": [
+                                                {
+                                                    "arguments": {
+                                                        "delimiter": " ",
+                                                        "list_to_concatenate": {
+                                                            "identifier": ["first-name", "last-name"],
+                                                            "source": "answers"
+                                                        }
+                                                    },
+                                                    "transform": "concatenate_list"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "type": "RelationshipCollector",
+                            "id": "relationships",
+                            "title": "This will iterate over the people list, capturing the one way relationships.",
+                            "for_list": "people",
+                            "question": {
+                                "id": "relationship-question",
+                                "type": "General",
+                                "title": {
+                                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>…</em>",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "first_person_name",
+                                            "transforms": [
+                                                {
+                                                    "transform": "concatenate_list",
+                                                    "arguments": {
+                                                        "list_to_concatenate": {
+                                                            "source": "answers",
+                                                            "identifier": ["first-name", "last-name"],
+                                                            "list_item_selector": {
+                                                                "source": "location",
+                                                                "id": "list_item_id"
+                                                            }
+                                                        },
+                                                        "delimiter": " "
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "placeholder": "second_person_name",
+                                            "transforms": [
+                                                {
+                                                    "transform": "concatenate_list",
+                                                    "arguments": {
+                                                        "list_to_concatenate": {
+                                                            "source": "answers",
+                                                            "identifier": ["first-name", "last-name"],
+                                                            "list_item_selector": {
+                                                                "source": "location",
+                                                                "id": "to_list_item_id"
+                                                            }
+                                                        },
+                                                        "delimiter": " "
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "answers": [
+                                    {
+                                        "id": "relationship-answer",
+                                        "mandatory": true,
+                                        "type": "Relationship",
+                                        "playback": {
+                                            "text": "{second_person_name} is {first_person_name_possessive} <em>…</em>",
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "first_person_name_possessive",
+                                                    "transforms": [
+                                                        {
+                                                            "transform": "concatenate_list",
+                                                            "arguments": {
+                                                                "list_to_concatenate": {
+                                                                    "source": "answers",
+                                                                    "identifier": ["first-name", "last-name"],
+                                                                    "list_item_selector": {
+                                                                        "source": "location",
+                                                                        "id": "list_item_id"
+                                                                    }
+                                                                },
+                                                                "delimiter": " "
+                                                            }
+                                                        },
+                                                        {
+                                                            "transform": "format_possessive",
+                                                            "arguments": {
+                                                                "string_to_format": {
+                                                                    "source": "previous_transform"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "placeholder": "second_person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "transform": "concatenate_list",
+                                                            "arguments": {
+                                                                "list_to_concatenate": {
+                                                                    "source": "answers",
+                                                                    "identifier": ["first-name", "last-name"],
+                                                                    "list_item_selector": {
+                                                                        "source": "location",
+                                                                        "id": "to_list_item_id"
+                                                                    }
+                                                                },
+                                                                "delimiter": " "
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "options": [
+                                            {
+                                                "label": "Husband or Wife",
+                                                "value": "Husband or Wife",
+                                                "title": {
+                                                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                                                    "placeholders": [
+                                                        {
+                                                            "placeholder": "first_person_name",
+                                                            "transforms": [
+                                                                {
+                                                                    "transform": "concatenate_list",
+                                                                    "arguments": {
+                                                                        "list_to_concatenate": {
+                                                                            "source": "answers",
+                                                                            "identifier": ["first-name", "last-name"],
+                                                                            "list_item_selector": {
+                                                                                "source": "location",
+                                                                                "id": "list_item_id"
+                                                                            }
+                                                                        },
+                                                                        "delimiter": " "
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "placeholder": "second_person_name",
+                                                            "transforms": [
+                                                                {
+                                                                    "transform": "concatenate_list",
+                                                                    "arguments": {
+                                                                        "list_to_concatenate": {
+                                                                            "source": "answers",
+                                                                            "identifier": ["first-name", "last-name"],
+                                                                            "list_item_selector": {
+                                                                                "source": "location",
+                                                                                "id": "to_list_item_id"
+                                                                            }
+                                                                        },
+                                                                        "delimiter": " "
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "playback": {
+                                                    "text": "{second_person_name} is {first_person_name_possessive} <em>husband or wife</em>",
+                                                    "placeholders": [
+                                                        {
+                                                            "placeholder": "first_person_name_possessive",
+                                                            "transforms": [
+                                                                {
+                                                                    "transform": "concatenate_list",
+                                                                    "arguments": {
+                                                                        "list_to_concatenate": {
+                                                                            "source": "answers",
+                                                                            "identifier": ["first-name", "last-name"],
+                                                                            "list_item_selector": {
+                                                                                "source": "location",
+                                                                                "id": "list_item_id"
+                                                                            }
+                                                                        },
+                                                                        "delimiter": " "
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "transform": "format_possessive",
+                                                                    "arguments": {
+                                                                        "string_to_format": {
+                                                                            "source": "previous_transform"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "placeholder": "second_person_name",
+                                                            "transforms": [
+                                                                {
+                                                                    "transform": "concatenate_list",
+                                                                    "arguments": {
+                                                                        "list_to_concatenate": {
+                                                                            "source": "answers",
+                                                                            "identifier": ["first-name", "last-name"],
+                                                                            "list_item_selector": {
+                                                                                "source": "location",
+                                                                                "id": "to_list_item_id"
+                                                                            }
+                                                                        },
+                                                                        "delimiter": " "
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "label": "Unrelated",
+                                                "value": "Unrelated",
+                                                "title": {
+                                                    "text": "{second_person_name} is <em>unrelated</em> to {first_person_name}",
+                                                    "placeholders": [
+                                                        {
+                                                            "placeholder": "first_person_name",
+                                                            "transforms": [
+                                                                {
+                                                                    "transform": "concatenate_list",
+                                                                    "arguments": {
+                                                                        "list_to_concatenate": {
+                                                                            "source": "answers",
+                                                                            "identifier": ["first-name", "last-name"],
+                                                                            "list_item_selector": {
+                                                                                "source": "location",
+                                                                                "id": "list_item_id"
+                                                                            }
+                                                                        },
+                                                                        "delimiter": " "
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "placeholder": "second_person_name",
+                                                            "transforms": [
+                                                                {
+                                                                    "transform": "concatenate_list",
+                                                                    "arguments": {
+                                                                        "list_to_concatenate": {
+                                                                            "source": "answers",
+                                                                            "identifier": ["first-name", "last-name"],
+                                                                            "list_item_selector": {
+                                                                                "source": "location",
+                                                                                "id": "to_list_item_id"
+                                                                            }
+                                                                        },
+                                                                        "delimiter": " "
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "playback": {
+                                                    "text": "{second_person_name} is {first_person_name_possessive} <em>brother or sister</em>",
+                                                    "placeholders": [
+                                                        {
+                                                            "placeholder": "first_person_name_possessive",
+                                                            "transforms": [
+                                                                {
+                                                                    "transform": "concatenate_list",
+                                                                    "arguments": {
+                                                                        "list_to_concatenate": {
+                                                                            "source": "answers",
+                                                                            "identifier": ["first-name", "last-name"],
+                                                                            "list_item_selector": {
+                                                                                "source": "location",
+                                                                                "id": "list_item_id"
+                                                                            }
+                                                                        },
+                                                                        "delimiter": " "
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "transform": "format_possessive",
+                                                                    "arguments": {
+                                                                        "string_to_format": {
+                                                                            "source": "previous_transform"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "placeholder": "second_person_name",
+                                                            "transforms": [
+                                                                {
+                                                                    "transform": "concatenate_list",
+                                                                    "arguments": {
+                                                                        "list_to_concatenate": {
+                                                                            "source": "answers",
+                                                                            "identifier": ["first-name", "last-name"],
+                                                                            "list_item_selector": {
+                                                                                "source": "location",
+                                                                                "id": "to_list_item_id"
+                                                                            }
+                                                                        },
+                                                                        "delimiter": " "
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "description": "Including half brother or half sister"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "list": "people",
+                                            "condition": "less than",
+                                            "value": 2
+                                        }
+                                    ]
+                                }
+                            ],
+                            "unrelated_block": {
+                                "type": "UnrelatedQuestion",
+                                "id": "related-to-anyone-else",
+                                "page_title": "How person {list_item_position} is related to anyone else",
+                                "title": "Related to anyone",
+                                "list_summary": {
+                                    "for_list": "people",
+                                    "summary": {
+                                        "item_title": {
+                                            "placeholders": [
+                                                {
+                                                    "placeholder": "person_name",
+                                                    "transforms": [
+                                                        {
+                                                            "arguments": {
+                                                                "delimiter": " ",
+                                                                "list_to_concatenate": {
+                                                                    "identifier": ["first-name", "last-name"],
+                                                                    "source": "answers"
+                                                                }
+                                                            },
+                                                            "transform": "concatenate_list"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "text": "{person_name}"
+                                        }
+                                    }
+                                },
+                                "question": {
+                                    "id": "relationship-question",
+                                    "type": "General",
+                                    "title": "Are any of these people related to you?",
+                                    "guidance": {
+                                        "contents": [
+                                            {
+                                                "description": "Remember to include partners, step-parents, and stepchildren as related"
+                                            }
+                                        ]
+                                    },
+                                    "answers": [
+                                        {
+                                            "id": "relationship-answer",
+                                            "mandatory": true,
+                                            "type": "Radio",
+                                            "options": [
+                                                {
+                                                    "label": "Yes",
+                                                    "value": "Yes"
+                                                },
+                                                {
+                                                    "label": "No",
+                                                    "value": "No"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "id": "relationship-interstitial",
+                            "content": {
+                                "title": "Relationship section",
+                                "contents": [
+                                    {
+                                        "description": "You have successfully completed the relationship section."
+                                    }
+                                ]
+                            },
+                            "type": "Interstitial",
+                            "skip_conditions": [
+                                {
+                                    "when": [
+                                        {
+                                            "list": "people",
+                                            "condition": "less than",
+                                            "value": 2
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "summary-section",
+            "title": "Summary",
+            "groups": [
+                {
+                    "id": "summary-group",
+                    "title": "Summary",
+                    "blocks": [
+                        {
+                            "id": "summary",
+                            "type": "Summary"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/schemas/valid/test_relationships_unrelated.json
+++ b/tests/schemas/valid/test_relationships_unrelated.json
@@ -1,598 +1,598 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "language": "en",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.3",
-    "survey_id": "0",
-    "title": "Test Relationships Unrelated Question",
-    "theme": "default",
-    "description": "A questionnaire to test capturing of relationships.",
-    "messages": {},
-    "metadata": [
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test Relationships Unrelated Question",
+  "theme": "default",
+  "description": "A questionnaire to test capturing of relationships.",
+  "messages": {},
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "section",
+      "summary": {
+        "show_on_completion": true,
+        "items": [
+          {
+            "add_link_text": "Add someone to this household",
+            "empty_list_text": "There are no householders",
+            "for_list": "people",
+            "title": "Household members",
+            "type": "List"
+          }
+        ]
+      },
+      "groups": [
         {
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
-    "sections": [
-        {
-            "id": "section",
-            "summary": {
-                "show_on_completion": true,
-                "items": [
-                    {
-                        "add_link_text": "Add someone to this household",
-                        "empty_list_text": "There are no householders",
-                        "for_list": "people",
-                        "title": "Household members",
-                        "type": "List"
-                    }
+          "id": "group",
+          "title": "Relationships",
+          "blocks": [
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "for_list": "people",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Does anyone else live at 1 Pleasant Lane?",
+                "answers": [
+                  {
+                    "id": "anyone-else",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
                 ]
+              },
+              "add_block": {
+                "id": "add-person",
+                "type": "ListAddQuestion",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What is the name of the person who isn’t you?",
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-person",
+                "type": "ListEditQuestion",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-person",
+                "type": "ListRemoveQuestion",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this person?",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "People who live here",
+                "item_title": {
+                  "text": "{person_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": {
+                              "identifier": ["first-name", "last-name"],
+                              "source": "answers"
+                            }
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
             },
-            "groups": [
-                {
-                    "id": "group",
-                    "title": "Relationships",
-                    "blocks": [
+            {
+              "type": "RelationshipCollector",
+              "id": "relationships",
+              "title": "This will iterate over the people list, capturing the one way relationships.",
+              "for_list": "people",
+              "question": {
+                "id": "relationship-question",
+                "type": "General",
+                "title": {
+                  "text": "Thinking of {first_person_name}, {second_person_name} is their <em>…</em>",
+                  "placeholders": [
+                    {
+                      "placeholder": "first_person_name",
+                      "transforms": [
                         {
-                            "id": "list-collector",
-                            "type": "ListCollector",
-                            "for_list": "people",
-                            "question": {
-                                "id": "confirmation-question",
-                                "type": "General",
-                                "title": "Does anyone else live at 1 Pleasant Lane?",
-                                "answers": [
-                                    {
-                                        "id": "anyone-else",
-                                        "mandatory": true,
-                                        "type": "Radio",
-                                        "options": [
-                                            {
-                                                "label": "Yes",
-                                                "value": "Yes",
-                                                "action": {
-                                                    "type": "RedirectToListAddBlock"
-                                                }
-                                            },
-                                            {
-                                                "label": "No",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }
-                                ]
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "list_item_id"
+                              }
                             },
-                            "add_block": {
-                                "id": "add-person",
-                                "type": "ListAddQuestion",
-                                "question": {
-                                    "id": "add-question",
-                                    "type": "General",
-                                    "title": "What is the name of the person who isn’t you?",
-                                    "answers": [
-                                        {
-                                            "id": "first-name",
-                                            "label": "First name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        },
-                                        {
-                                            "id": "last-name",
-                                            "label": "Last name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        }
-                                    ]
-                                }
+                            "delimiter": " "
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "placeholder": "second_person_name",
+                      "transforms": [
+                        {
+                          "transform": "concatenate_list",
+                          "arguments": {
+                            "list_to_concatenate": {
+                              "source": "answers",
+                              "identifier": ["first-name", "last-name"],
+                              "list_item_selector": {
+                                "source": "location",
+                                "id": "to_list_item_id"
+                              }
                             },
-                            "edit_block": {
-                                "id": "edit-person",
-                                "type": "ListEditQuestion",
-                                "question": {
-                                    "id": "edit-question",
-                                    "type": "General",
-                                    "title": "What is the name of the person?",
-                                    "answers": [
-                                        {
-                                            "id": "first-name",
-                                            "label": "First name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        },
-                                        {
-                                            "id": "last-name",
-                                            "label": "Last name",
-                                            "mandatory": true,
-                                            "type": "TextField"
-                                        }
-                                    ]
-                                }
+                            "delimiter": " "
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "answers": [
+                  {
+                    "id": "relationship-answer",
+                    "mandatory": true,
+                    "type": "Relationship",
+                    "playback": {
+                      "text": "{second_person_name} is {first_person_name_possessive} <em>…</em>",
+                      "placeholders": [
+                        {
+                          "placeholder": "first_person_name_possessive",
+                          "transforms": [
+                            {
+                              "transform": "concatenate_list",
+                              "arguments": {
+                                "list_to_concatenate": {
+                                  "source": "answers",
+                                  "identifier": ["first-name", "last-name"],
+                                  "list_item_selector": {
+                                    "source": "location",
+                                    "id": "list_item_id"
+                                  }
+                                },
+                                "delimiter": " "
+                              }
                             },
-                            "remove_block": {
-                                "id": "remove-person",
-                                "type": "ListRemoveQuestion",
-                                "question": {
-                                    "id": "remove-question",
-                                    "type": "General",
-                                    "title": "Are you sure you want to remove this person?",
-                                    "answers": [
-                                        {
-                                            "id": "remove-confirmation",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes",
-                                                    "action": {
-                                                        "type": "RemoveListItemAndAnswers"
-                                                    }
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                }
-                                            ]
-                                        }
-                                    ]
+                            {
+                              "transform": "format_possessive",
+                              "arguments": {
+                                "string_to_format": {
+                                  "source": "previous_transform"
                                 }
-                            },
-                            "summary": {
-                                "title": "People who live here",
-                                "item_title": {
-                                    "text": "{person_name}",
-                                    "placeholders": [
-                                        {
-                                            "placeholder": "person_name",
-                                            "transforms": [
-                                                {
-                                                    "arguments": {
-                                                        "delimiter": " ",
-                                                        "list_to_concatenate": {
-                                                            "identifier": ["first-name", "last-name"],
-                                                            "source": "answers"
-                                                        }
-                                                    },
-                                                    "transform": "concatenate_list"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
+                              }
                             }
+                          ]
                         },
                         {
-                            "type": "RelationshipCollector",
-                            "id": "relationships",
-                            "title": "This will iterate over the people list, capturing the one way relationships.",
-                            "for_list": "people",
-                            "question": {
-                                "id": "relationship-question",
-                                "type": "General",
-                                "title": {
-                                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>…</em>",
-                                    "placeholders": [
-                                        {
-                                            "placeholder": "first_person_name",
-                                            "transforms": [
-                                                {
-                                                    "transform": "concatenate_list",
-                                                    "arguments": {
-                                                        "list_to_concatenate": {
-                                                            "source": "answers",
-                                                            "identifier": ["first-name", "last-name"],
-                                                            "list_item_selector": {
-                                                                "source": "location",
-                                                                "id": "list_item_id"
-                                                            }
-                                                        },
-                                                        "delimiter": " "
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "placeholder": "second_person_name",
-                                            "transforms": [
-                                                {
-                                                    "transform": "concatenate_list",
-                                                    "arguments": {
-                                                        "list_to_concatenate": {
-                                                            "source": "answers",
-                                                            "identifier": ["first-name", "last-name"],
-                                                            "list_item_selector": {
-                                                                "source": "location",
-                                                                "id": "to_list_item_id"
-                                                            }
-                                                        },
-                                                        "delimiter": " "
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
+                          "placeholder": "second_person_name",
+                          "transforms": [
+                            {
+                              "transform": "concatenate_list",
+                              "arguments": {
+                                "list_to_concatenate": {
+                                  "source": "answers",
+                                  "identifier": ["first-name", "last-name"],
+                                  "list_item_selector": {
+                                    "source": "location",
+                                    "id": "to_list_item_id"
+                                  }
                                 },
-                                "answers": [
-                                    {
-                                        "id": "relationship-answer",
-                                        "mandatory": true,
-                                        "type": "Relationship",
-                                        "playback": {
-                                            "text": "{second_person_name} is {first_person_name_possessive} <em>…</em>",
-                                            "placeholders": [
-                                                {
-                                                    "placeholder": "first_person_name_possessive",
-                                                    "transforms": [
-                                                        {
-                                                            "transform": "concatenate_list",
-                                                            "arguments": {
-                                                                "list_to_concatenate": {
-                                                                    "source": "answers",
-                                                                    "identifier": ["first-name", "last-name"],
-                                                                    "list_item_selector": {
-                                                                        "source": "location",
-                                                                        "id": "list_item_id"
-                                                                    }
-                                                                },
-                                                                "delimiter": " "
-                                                            }
-                                                        },
-                                                        {
-                                                            "transform": "format_possessive",
-                                                            "arguments": {
-                                                                "string_to_format": {
-                                                                    "source": "previous_transform"
-                                                                }
-                                                            }
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "placeholder": "second_person_name",
-                                                    "transforms": [
-                                                        {
-                                                            "transform": "concatenate_list",
-                                                            "arguments": {
-                                                                "list_to_concatenate": {
-                                                                    "source": "answers",
-                                                                    "identifier": ["first-name", "last-name"],
-                                                                    "list_item_selector": {
-                                                                        "source": "location",
-                                                                        "id": "to_list_item_id"
-                                                                    }
-                                                                },
-                                                                "delimiter": " "
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        "options": [
-                                            {
-                                                "label": "Husband or Wife",
-                                                "value": "Husband or Wife",
-                                                "title": {
-                                                    "text": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
-                                                    "placeholders": [
-                                                        {
-                                                            "placeholder": "first_person_name",
-                                                            "transforms": [
-                                                                {
-                                                                    "transform": "concatenate_list",
-                                                                    "arguments": {
-                                                                        "list_to_concatenate": {
-                                                                            "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"],
-                                                                            "list_item_selector": {
-                                                                                "source": "location",
-                                                                                "id": "list_item_id"
-                                                                            }
-                                                                        },
-                                                                        "delimiter": " "
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "placeholder": "second_person_name",
-                                                            "transforms": [
-                                                                {
-                                                                    "transform": "concatenate_list",
-                                                                    "arguments": {
-                                                                        "list_to_concatenate": {
-                                                                            "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"],
-                                                                            "list_item_selector": {
-                                                                                "source": "location",
-                                                                                "id": "to_list_item_id"
-                                                                            }
-                                                                        },
-                                                                        "delimiter": " "
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                "playback": {
-                                                    "text": "{second_person_name} is {first_person_name_possessive} <em>husband or wife</em>",
-                                                    "placeholders": [
-                                                        {
-                                                            "placeholder": "first_person_name_possessive",
-                                                            "transforms": [
-                                                                {
-                                                                    "transform": "concatenate_list",
-                                                                    "arguments": {
-                                                                        "list_to_concatenate": {
-                                                                            "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"],
-                                                                            "list_item_selector": {
-                                                                                "source": "location",
-                                                                                "id": "list_item_id"
-                                                                            }
-                                                                        },
-                                                                        "delimiter": " "
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "transform": "format_possessive",
-                                                                    "arguments": {
-                                                                        "string_to_format": {
-                                                                            "source": "previous_transform"
-                                                                        }
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "placeholder": "second_person_name",
-                                                            "transforms": [
-                                                                {
-                                                                    "transform": "concatenate_list",
-                                                                    "arguments": {
-                                                                        "list_to_concatenate": {
-                                                                            "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"],
-                                                                            "list_item_selector": {
-                                                                                "source": "location",
-                                                                                "id": "to_list_item_id"
-                                                                            }
-                                                                        },
-                                                                        "delimiter": " "
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "label": "Unrelated",
-                                                "value": "Unrelated",
-                                                "title": {
-                                                    "text": "{second_person_name} is <em>unrelated</em> to {first_person_name}",
-                                                    "placeholders": [
-                                                        {
-                                                            "placeholder": "first_person_name",
-                                                            "transforms": [
-                                                                {
-                                                                    "transform": "concatenate_list",
-                                                                    "arguments": {
-                                                                        "list_to_concatenate": {
-                                                                            "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"],
-                                                                            "list_item_selector": {
-                                                                                "source": "location",
-                                                                                "id": "list_item_id"
-                                                                            }
-                                                                        },
-                                                                        "delimiter": " "
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "placeholder": "second_person_name",
-                                                            "transforms": [
-                                                                {
-                                                                    "transform": "concatenate_list",
-                                                                    "arguments": {
-                                                                        "list_to_concatenate": {
-                                                                            "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"],
-                                                                            "list_item_selector": {
-                                                                                "source": "location",
-                                                                                "id": "to_list_item_id"
-                                                                            }
-                                                                        },
-                                                                        "delimiter": " "
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                "playback": {
-                                                    "text": "{second_person_name} is {first_person_name_possessive} <em>brother or sister</em>",
-                                                    "placeholders": [
-                                                        {
-                                                            "placeholder": "first_person_name_possessive",
-                                                            "transforms": [
-                                                                {
-                                                                    "transform": "concatenate_list",
-                                                                    "arguments": {
-                                                                        "list_to_concatenate": {
-                                                                            "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"],
-                                                                            "list_item_selector": {
-                                                                                "source": "location",
-                                                                                "id": "list_item_id"
-                                                                            }
-                                                                        },
-                                                                        "delimiter": " "
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "transform": "format_possessive",
-                                                                    "arguments": {
-                                                                        "string_to_format": {
-                                                                            "source": "previous_transform"
-                                                                        }
-                                                                    }
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "placeholder": "second_person_name",
-                                                            "transforms": [
-                                                                {
-                                                                    "transform": "concatenate_list",
-                                                                    "arguments": {
-                                                                        "list_to_concatenate": {
-                                                                            "source": "answers",
-                                                                            "identifier": ["first-name", "last-name"],
-                                                                            "list_item_selector": {
-                                                                                "source": "location",
-                                                                                "id": "to_list_item_id"
-                                                                            }
-                                                                        },
-                                                                        "delimiter": " "
-                                                                    }
-                                                                }
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                "description": "Including half brother or half sister"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            "skip_conditions": [
+                                "delimiter": " "
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "options": [
+                      {
+                        "label": "Husband or Wife",
+                        "value": "Husband or Wife",
+                        "title": {
+                          "text": "Thinking of {first_person_name}, {second_person_name} is their <em>husband or wife</em>",
+                          "placeholders": [
+                            {
+                              "placeholder": "first_person_name",
+                              "transforms": [
                                 {
-                                    "when": [
-                                        {
-                                            "list": "people",
-                                            "condition": "less than",
-                                            "value": 2
-                                        }
-                                    ]
-                                }
-                            ],
-                            "unrelated_block": {
-                                "type": "UnrelatedQuestion",
-                                "id": "related-to-anyone-else",
-                                "page_title": "How person {list_item_position} is related to anyone else",
-                                "title": "Related to anyone",
-                                "list_summary": {
-                                    "for_list": "people",
-                                    "summary": {
-                                        "item_title": {
-                                            "placeholders": [
-                                                {
-                                                    "placeholder": "person_name",
-                                                    "transforms": [
-                                                        {
-                                                            "arguments": {
-                                                                "delimiter": " ",
-                                                                "list_to_concatenate": {
-                                                                    "identifier": ["first-name", "last-name"],
-                                                                    "source": "answers"
-                                                                }
-                                                            },
-                                                            "transform": "concatenate_list"
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "text": "{person_name}"
-                                        }
-                                    }
-                                },
-                                "question": {
-                                    "id": "relationship-question",
-                                    "type": "General",
-                                    "title": "Are any of these people related to you?",
-                                    "guidance": {
-                                        "contents": [
-                                            {
-                                                "description": "Remember to include partners, step-parents, and stepchildren as related"
-                                            }
-                                        ]
+                                  "transform": "concatenate_list",
+                                  "arguments": {
+                                    "list_to_concatenate": {
+                                      "source": "answers",
+                                      "identifier": ["first-name", "last-name"],
+                                      "list_item_selector": {
+                                        "source": "location",
+                                        "id": "list_item_id"
+                                      }
                                     },
-                                    "answers": [
-                                        {
-                                            "id": "relationship-answer",
-                                            "mandatory": true,
-                                            "type": "Radio",
-                                            "options": [
-                                                {
-                                                    "label": "Yes",
-                                                    "value": "Yes"
-                                                },
-                                                {
-                                                    "label": "No",
-                                                    "value": "No"
-                                                }
-                                            ]
-                                        }
-                                    ]
+                                    "delimiter": " "
+                                  }
                                 }
+                              ]
+                            },
+                            {
+                              "placeholder": "second_person_name",
+                              "transforms": [
+                                {
+                                  "transform": "concatenate_list",
+                                  "arguments": {
+                                    "list_to_concatenate": {
+                                      "source": "answers",
+                                      "identifier": ["first-name", "last-name"],
+                                      "list_item_selector": {
+                                        "source": "location",
+                                        "id": "to_list_item_id"
+                                      }
+                                    },
+                                    "delimiter": " "
+                                  }
+                                }
+                              ]
                             }
+                          ]
+                        },
+                        "playback": {
+                          "text": "{second_person_name} is {first_person_name_possessive} <em>husband or wife</em>",
+                          "placeholders": [
+                            {
+                              "placeholder": "first_person_name_possessive",
+                              "transforms": [
+                                {
+                                  "transform": "concatenate_list",
+                                  "arguments": {
+                                    "list_to_concatenate": {
+                                      "source": "answers",
+                                      "identifier": ["first-name", "last-name"],
+                                      "list_item_selector": {
+                                        "source": "location",
+                                        "id": "list_item_id"
+                                      }
+                                    },
+                                    "delimiter": " "
+                                  }
+                                },
+                                {
+                                  "transform": "format_possessive",
+                                  "arguments": {
+                                    "string_to_format": {
+                                      "source": "previous_transform"
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "placeholder": "second_person_name",
+                              "transforms": [
+                                {
+                                  "transform": "concatenate_list",
+                                  "arguments": {
+                                    "list_to_concatenate": {
+                                      "source": "answers",
+                                      "identifier": ["first-name", "last-name"],
+                                      "list_item_selector": {
+                                        "source": "location",
+                                        "id": "to_list_item_id"
+                                      }
+                                    },
+                                    "delimiter": " "
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "label": "Unrelated",
+                        "value": "Unrelated",
+                        "title": {
+                          "text": "{second_person_name} is <em>unrelated</em> to {first_person_name}",
+                          "placeholders": [
+                            {
+                              "placeholder": "first_person_name",
+                              "transforms": [
+                                {
+                                  "transform": "concatenate_list",
+                                  "arguments": {
+                                    "list_to_concatenate": {
+                                      "source": "answers",
+                                      "identifier": ["first-name", "last-name"],
+                                      "list_item_selector": {
+                                        "source": "location",
+                                        "id": "list_item_id"
+                                      }
+                                    },
+                                    "delimiter": " "
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "placeholder": "second_person_name",
+                              "transforms": [
+                                {
+                                  "transform": "concatenate_list",
+                                  "arguments": {
+                                    "list_to_concatenate": {
+                                      "source": "answers",
+                                      "identifier": ["first-name", "last-name"],
+                                      "list_item_selector": {
+                                        "source": "location",
+                                        "id": "to_list_item_id"
+                                      }
+                                    },
+                                    "delimiter": " "
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "playback": {
+                          "text": "{second_person_name} is {first_person_name_possessive} <em>brother or sister</em>",
+                          "placeholders": [
+                            {
+                              "placeholder": "first_person_name_possessive",
+                              "transforms": [
+                                {
+                                  "transform": "concatenate_list",
+                                  "arguments": {
+                                    "list_to_concatenate": {
+                                      "source": "answers",
+                                      "identifier": ["first-name", "last-name"],
+                                      "list_item_selector": {
+                                        "source": "location",
+                                        "id": "list_item_id"
+                                      }
+                                    },
+                                    "delimiter": " "
+                                  }
+                                },
+                                {
+                                  "transform": "format_possessive",
+                                  "arguments": {
+                                    "string_to_format": {
+                                      "source": "previous_transform"
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "placeholder": "second_person_name",
+                              "transforms": [
+                                {
+                                  "transform": "concatenate_list",
+                                  "arguments": {
+                                    "list_to_concatenate": {
+                                      "source": "answers",
+                                      "identifier": ["first-name", "last-name"],
+                                      "list_item_selector": {
+                                        "source": "location",
+                                        "id": "to_list_item_id"
+                                      }
+                                    },
+                                    "delimiter": " "
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "description": "Including half brother or half sister"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "skip_conditions": [
+                {
+                  "when": [
+                    {
+                      "list": "people",
+                      "condition": "less than",
+                      "value": 2
+                    }
+                  ]
+                }
+              ],
+              "unrelated_block": {
+                "type": "UnrelatedQuestion",
+                "id": "related-to-anyone-else",
+                "page_title": "How person {list_item_position} is related to anyone else",
+                "title": "Related to anyone",
+                "list_summary": {
+                  "for_list": "people",
+                  "summary": {
+                    "item_title": {
+                      "placeholders": [
+                        {
+                          "placeholder": "person_name",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": {
+                                  "identifier": ["first-name", "last-name"],
+                                  "source": "answers"
+                                }
+                              },
+                              "transform": "concatenate_list"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "{person_name}"
+                    }
+                  }
+                },
+                "question": {
+                  "id": "relationship-question",
+                  "type": "General",
+                  "title": "Are any of these people related to you?",
+                  "guidance": {
+                    "contents": [
+                      {
+                        "description": "Remember to include partners, step-parents, and stepchildren as related"
+                      }
+                    ]
+                  },
+                  "answers": [
+                    {
+                      "id": "relationship-answer",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes"
                         },
                         {
-                            "id": "relationship-interstitial",
-                            "content": {
-                                "title": "Relationship section",
-                                "contents": [
-                                    {
-                                        "description": "You have successfully completed the relationship section."
-                                    }
-                                ]
-                            },
-                            "type": "Interstitial",
-                            "skip_conditions": [
-                                {
-                                    "when": [
-                                        {
-                                            "list": "people",
-                                            "condition": "less than",
-                                            "value": 2
-                                        }
-                                    ]
-                                }
-                            ]
+                          "label": "No",
+                          "value": "No"
                         }
-                    ]
+                      ]
+                    }
+                  ]
                 }
-            ]
-        },
-        {
-            "id": "summary-section",
-            "title": "Summary",
-            "groups": [
+              }
+            },
+            {
+              "id": "relationship-interstitial",
+              "content": {
+                "title": "Relationship section",
+                "contents": [
+                  {
+                    "description": "You have successfully completed the relationship section."
+                  }
+                ]
+              },
+              "type": "Interstitial",
+              "skip_conditions": [
                 {
-                    "id": "summary-group",
-                    "title": "Summary",
-                    "blocks": [
-                        {
-                            "id": "summary",
-                            "type": "Summary"
-                        }
-                    ]
+                  "when": [
+                    {
+                      "list": "people",
+                      "condition": "less than",
+                      "value": 2
+                    }
+                  ]
                 }
-            ]
+              ]
+            }
+          ]
         }
-    ]
+      ]
+    },
+    {
+      "id": "summary-section",
+      "title": "Summary",
+      "groups": [
+        {
+          "id": "summary-group",
+          "title": "Summary",
+          "blocks": [
+            {
+              "id": "summary",
+              "type": "Summary"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### PR Context
Adds support for the unrelated relationships block implement in https://github.com/ONSdigital/eq-questionnaire-runner/pull/339

To keep relationships consistent, I have enforced `RelationshipCollector` to have an ID of `relationships`. This makes grouping relationship routes in runner easier and avoid hardcoding the ID for the unrelated block.

Open to suggestions in terms of naming the new block.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
