### PR TITLE
Add survey, form_type and region_code to schema definitions

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -51,10 +51,12 @@
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
     },
     "survey": {
-      "enum": ["CENSUS", "CCS"]
+      "enum": ["CENSUS", "CCS"],
+      "description": "The survey (Census/Census Coverage Survey) that this address has been sampled into for participation"
     },
     "form_type": {
-      "enum": ["H", "I", "C"]
+      "enum": ["H", "I", "C"],
+      "description": "The form types are Household (H), CE1 (C) and Individual (I)"
     },
     "region_code": {
       "type": "string",

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -52,7 +52,7 @@
     },
     "survey": {
       "enum": ["CENSUS", "CCS"],
-      "description": "The survey (Census/Census Coverage Survey) that this schema has been sampled into for participation"
+      "description": "The survey (Census or Census Coverage Survey) that an address has been sampled into for participation"
     },
     "form_type": {
       "enum": ["H", "I", "C"],
@@ -60,7 +60,8 @@
     },
     "region_code": {
       "type": "string",
-      "pattern": "^GB-[A-Z]{3}$"
+      "pattern": "^GB-[A-Z]{3}$",
+      "description": "An ISO 3166-2:GB region code"
     },
     "metadata": {
       "type": "array",

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -20,14 +20,6 @@
     "messages": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/messages"
     },
-    "eq_id": {
-      "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-      "description": "Used in combination with the form_type to uniquely identify a questionnaire."
-    },
-    "form_type": {
-      "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-      "description": "Used in combination with the eq_id to uniquely identify a questionnaire."
-    },
     "mime_type": {
       "type": "string"
     },
@@ -57,6 +49,16 @@
     },
     "legal_basis": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+    },
+    "survey": {
+      "enum": ["CENSUS", "CCS"]
+    },
+    "form_type": {
+      "enum": ["H", "I", "C"]
+    },
+    "region_code": {
+      "type": "string",
+      "pattern": "^GB-[A-Z]{3}$"
     },
     "metadata": {
       "type": "array",

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -52,7 +52,7 @@
     },
     "survey": {
       "enum": ["CENSUS", "CCS"],
-      "description": "The survey (Census/Census Coverage Survey) that this address has been sampled into for participation"
+      "description": "The survey (Census/Census Coverage Survey) that this schema has been sampled into for participation"
     },
     "form_type": {
       "enum": ["H", "I", "C"],

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -56,7 +56,7 @@
     },
     "form_type": {
       "enum": ["H", "I", "C"],
-      "description": "The form types are Household (H), CE1 (C) and Individual (I)"
+      "description": "The form types are Household (H), Individual (I) or Communal Establishment (C)"
     },
     "region_code": {
       "type": "string",

--- a/tests/schemas/valid/test_placeholder_plurals.json
+++ b/tests/schemas/valid/test_placeholder_plurals.json
@@ -1,6 +1,4 @@
 {
-  "eq_id": "3",
-  "form_type": "3",
   "mime_type": "application/json/ons/eq",
   "language": "en",
   "schema_version": "0.0.1",

--- a/tests/schemas/valid/test_placeholder_source_ids.json
+++ b/tests/schemas/valid/test_placeholder_source_ids.json
@@ -1,6 +1,4 @@
 {
-  "eq_id": "3",
-  "form_type": "3",
   "mime_type": "application/json/ons/eq",
   "language": "en",
   "schema_version": "0.0.1",

--- a/tests/schemas/valid/test_string_transforms.json
+++ b/tests/schemas/valid/test_string_transforms.json
@@ -1,6 +1,4 @@
 {
-  "eq_id": "3",
-  "form_type": "3",
   "mime_type": "application/json/ons/eq",
   "language": "en",
   "schema_version": "0.0.1",

--- a/tests/schemas/valid/test_valid_census_top_level_properties.json
+++ b/tests/schemas/valid/test_valid_census_top_level_properties.json
@@ -4,6 +4,9 @@
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "3",
+  "survey": "CENSUS",
+  "form_type": "H",
+  "region_code": "GB-WLS",
   "title": "Metadata",
   "theme": "default",
   "legal_basis": "StatisticsOfTradeAct",
@@ -21,10 +24,6 @@
     },
     {
       "name": "ru_name",
-      "type": "string"
-    },
-    {
-      "name": "test_metadata",
       "type": "string"
     }
   ],


### PR DESCRIPTION
### PR Context
Adds/edit survey, form_type and region_code to the schema definitons to support census schema needs.

Test using https://github.com/ONSdigital/eq-questionnaire-runner/pull/362

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
