### PR TITLE
Add checkbox answer field no label definition

### DIFF
--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -88,7 +88,7 @@ class QuestionnaireValidator(Validator):
 
             for schema_text in values_to_check:
                 if schema_text and quote_regex.search(schema_text):
-                        self.add_error(
-                            error_messages.DUMB_QUOTES_FOUND,
-                            pointer=translatable_item.pointer,
-                        )
+                    self.add_error(
+                        error_messages.DUMB_QUOTES_FOUND,
+                        pointer=translatable_item.pointer,
+                    )

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -87,10 +87,7 @@ class QuestionnaireValidator(Validator):
                 values_to_check = schema_text.values()
 
             for schema_text in values_to_check:
-                if schema_text is not None:
-                    found = quote_regex.search(schema_text)
-
-                    if found:
+                if schema_text and quote_regex.search(schema_text):
                         self.add_error(
                             error_messages.DUMB_QUOTES_FOUND,
                             pointer=translatable_item.pointer,

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -87,10 +87,11 @@ class QuestionnaireValidator(Validator):
                 values_to_check = schema_text.values()
 
             for schema_text in values_to_check:
-                found = quote_regex.search(schema_text)
+                if schema_text is not None:
+                    found = quote_regex.search(schema_text)
 
-                if found:
-                    self.add_error(
-                        error_messages.DUMB_QUOTES_FOUND,
-                        pointer=translatable_item.pointer,
-                    )
+                    if found:
+                        self.add_error(
+                            error_messages.DUMB_QUOTES_FOUND,
+                            pointer=translatable_item.pointer,
+                        )

--- a/schemas/answers/checkbox.json
+++ b/schemas/answers/checkbox.json
@@ -55,16 +55,12 @@
     "dependencies": {
       "label": {
         "not": {
-          "required": [
-            "no_label"
-          ]
+          "required": ["no_label"]
         }
       },
       "no_label": {
         "not": {
-          "required": [
-            "label"
-          ]
+          "required": ["label"]
         }
       }
     }

--- a/schemas/answers/checkbox.json
+++ b/schemas/answers/checkbox.json
@@ -11,10 +11,14 @@
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/q_code"
       },
       "label": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
-      },
-      "show_label": {
-        "type": "boolean"
+        "oneOf": [
+          {
+            "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+          },
+          {
+            "type": "null"
+          }
+        ]
       },
       "guidance": {
         "$ref": "https://eq.ons.gov.uk/answers/definitions.json#/answer_guidance"
@@ -51,18 +55,6 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "mandatory", "options"],
-    "dependencies": {
-      "label": {
-        "not": {
-          "required": ["show_label"]
-        }
-      },
-      "show_label": {
-        "not": {
-          "required": ["label"]
-        }
-      }
-    }
+    "required": ["id", "type", "mandatory", "options"]
   }
 }

--- a/schemas/answers/checkbox.json
+++ b/schemas/answers/checkbox.json
@@ -13,7 +13,7 @@
       "label": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
-      "no_label": {
+      "show_label": {
         "type": "boolean"
       },
       "guidance": {
@@ -55,10 +55,10 @@
     "dependencies": {
       "label": {
         "not": {
-          "required": ["no_label"]
+          "required": ["show_label"]
         }
       },
-      "no_label": {
+      "show_label": {
         "not": {
           "required": ["label"]
         }

--- a/schemas/answers/checkbox.json
+++ b/schemas/answers/checkbox.json
@@ -13,6 +13,9 @@
       "label": {
         "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
       },
+      "no_label": {
+        "type": "boolean"
+      },
       "guidance": {
         "$ref": "https://eq.ons.gov.uk/answers/definitions.json#/answer_guidance"
       },
@@ -36,9 +39,6 @@
       "mandatory": {
         "type": "boolean"
       },
-      "no_label": {
-        "type": "boolean"
-      },
       "validation": {
         "type": "object",
         "properties": {
@@ -51,6 +51,22 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "mandatory", "options"]
+    "required": ["id", "type", "mandatory", "options"],
+    "dependencies": {
+      "label": {
+        "not": {
+          "required": [
+            "no_label"
+          ]
+        }
+      },
+      "no_label": {
+        "not": {
+          "required": [
+            "label"
+          ]
+        }
+      }
+    }
   }
 }

--- a/schemas/answers/checkbox.json
+++ b/schemas/answers/checkbox.json
@@ -36,6 +36,9 @@
       "mandatory": {
         "type": "boolean"
       },
+      "no_label": {
+        "type": "boolean"
+      },
       "validation": {
         "type": "object",
         "properties": {

--- a/tests/schemas/invalid/test_invalid_checkbox_label.json
+++ b/tests/schemas/invalid/test_invalid_checkbox_label.json
@@ -1,0 +1,101 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "0",
+    "title": "Other input fields",
+    "theme": "default",
+    "description": "A questionnaire to demo checkbox label and show_label properties.",
+    "messages": {
+        "NUMBER_TOO_LARGE": "Number is too large",
+        "NUMBER_TOO_SMALL": "Number cannot be less than zero",
+        "INVALID_NUMBER": "Please enter an integer"
+    },
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        }
+    ],
+    "sections": [
+        {
+            "id": "default-section",
+            "groups": [
+                {
+                    "blocks": [
+                        {
+                            "type": "Question",
+                            "id": "non-mandatory-checkbox",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "non-mandatory-checkbox-answer",
+                                        "label": "Select any answers that apply",
+                                        "show_label": false,
+                                        "mandatory": false,
+                                        "options": [
+                                            {
+                                                "label": "None",
+                                                "value": "None"
+                                            },
+                                            {
+                                                "label": "Cheese",
+                                                "value": "Cheese"
+                                            },
+                                            {
+                                                "label": "Ham",
+                                                "value": "Ham"
+                                            },
+                                            {
+                                                "label": "Pineapple",
+                                                "value": "Pineapple"
+                                            },
+                                            {
+                                                "label": "Tuna",
+                                                "value": "Tuna"
+                                            },
+                                            {
+                                                "label": "Pepperoni",
+                                                "value": "Pepperoni"
+                                            },
+                                            {
+                                                "label": "Other",
+                                                "value": "Other",
+                                                "description": "Choose any other topping",
+                                                "detail_answer": {
+                                                    "mandatory": false,
+                                                    "id": "other-answer-non-mandatory",
+                                                    "label": "Please specify other",
+                                                    "type": "TextField"
+                                                }
+                                            }
+                                        ],
+                                        "q_code": "20",
+                                        "type": "Checkbox"
+                                    }
+                                ],
+                                "id": "non-mandatory-checkbox-question",
+                                "title": "What extra toppings would you like?",
+                                "type": "General"
+                            }
+                        },
+                        {
+                            "type": "Summary",
+                            "id": "summary"
+                        }
+                    ],
+                    "id": "checkboxes"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/schemas/invalid/test_invalid_checkbox_label.json
+++ b/tests/schemas/invalid/test_invalid_checkbox_label.json
@@ -1,101 +1,101 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "language": "en",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.3",
-    "survey_id": "0",
-    "title": "Other input fields",
-    "theme": "default",
-    "description": "A questionnaire to demo checkbox label and show_label properties.",
-    "messages": {
-        "NUMBER_TOO_LARGE": "Number is too large",
-        "NUMBER_TOO_SMALL": "Number cannot be less than zero",
-        "INVALID_NUMBER": "Please enter an integer"
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Other input fields",
+  "theme": "default",
+  "description": "A questionnaire to demo checkbox label and show_label properties.",
+  "messages": {
+    "NUMBER_TOO_LARGE": "Number is too large",
+    "NUMBER_TOO_SMALL": "Number cannot be less than zero",
+    "INVALID_NUMBER": "Please enter an integer"
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
     },
-    "metadata": [
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "sections": [
+    {
+      "id": "default-section",
+      "groups": [
         {
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        }
-    ],
-    "sections": [
-        {
-            "id": "default-section",
-            "groups": [
-                {
-                    "blocks": [
-                        {
-                            "type": "Question",
-                            "id": "non-mandatory-checkbox",
-                            "question": {
-                                "answers": [
-                                    {
-                                        "id": "non-mandatory-checkbox-answer",
-                                        "label": "Select any answers that apply",
-                                        "show_label": false,
-                                        "mandatory": false,
-                                        "options": [
-                                            {
-                                                "label": "None",
-                                                "value": "None"
-                                            },
-                                            {
-                                                "label": "Cheese",
-                                                "value": "Cheese"
-                                            },
-                                            {
-                                                "label": "Ham",
-                                                "value": "Ham"
-                                            },
-                                            {
-                                                "label": "Pineapple",
-                                                "value": "Pineapple"
-                                            },
-                                            {
-                                                "label": "Tuna",
-                                                "value": "Tuna"
-                                            },
-                                            {
-                                                "label": "Pepperoni",
-                                                "value": "Pepperoni"
-                                            },
-                                            {
-                                                "label": "Other",
-                                                "value": "Other",
-                                                "description": "Choose any other topping",
-                                                "detail_answer": {
-                                                    "mandatory": false,
-                                                    "id": "other-answer-non-mandatory",
-                                                    "label": "Please specify other",
-                                                    "type": "TextField"
-                                                }
-                                            }
-                                        ],
-                                        "q_code": "20",
-                                        "type": "Checkbox"
-                                    }
-                                ],
-                                "id": "non-mandatory-checkbox-question",
-                                "title": "What extra toppings would you like?",
-                                "type": "General"
-                            }
-                        },
-                        {
-                            "type": "Summary",
-                            "id": "summary"
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "non-mandatory-checkbox",
+              "question": {
+                "answers": [
+                  {
+                    "id": "non-mandatory-checkbox-answer",
+                    "label": "Select any answers that apply",
+                    "show_label": false,
+                    "mandatory": false,
+                    "options": [
+                      {
+                        "label": "None",
+                        "value": "None"
+                      },
+                      {
+                        "label": "Cheese",
+                        "value": "Cheese"
+                      },
+                      {
+                        "label": "Ham",
+                        "value": "Ham"
+                      },
+                      {
+                        "label": "Pineapple",
+                        "value": "Pineapple"
+                      },
+                      {
+                        "label": "Tuna",
+                        "value": "Tuna"
+                      },
+                      {
+                        "label": "Pepperoni",
+                        "value": "Pepperoni"
+                      },
+                      {
+                        "label": "Other",
+                        "value": "Other",
+                        "description": "Choose any other topping",
+                        "detail_answer": {
+                          "mandatory": false,
+                          "id": "other-answer-non-mandatory",
+                          "label": "Please specify other",
+                          "type": "TextField"
                         }
+                      }
                     ],
-                    "id": "checkboxes"
-                }
-            ]
+                    "q_code": "20",
+                    "type": "Checkbox"
+                  }
+                ],
+                "id": "non-mandatory-checkbox-question",
+                "title": "What extra toppings would you like?",
+                "type": "General"
+              }
+            },
+            {
+              "type": "Summary",
+              "id": "summary"
+            }
+          ],
+          "id": "checkboxes"
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/tests/schemas/valid/test_checkbox_label.json
+++ b/tests/schemas/valid/test_checkbox_label.json
@@ -39,8 +39,7 @@
                 "answers": [
                   {
                     "id": "non-mandatory-checkbox-answer",
-                    "label": "Select any answers that apply",
-                    "show_label": false,
+                    "label": null,
                     "mandatory": false,
                     "options": [
                       {


### PR DESCRIPTION
### PR Context
This adds new "no_label" Boolean field to checkbox answer block definitions. It is required by this [card](https://trello.com/c/91PIVgpv) and associated with [this change](https://github.com/ONSdigital/eq-questionnaire-runner/pull/383) in runner and [schemas PR](https://github.com/ONSdigital/eq-questionnaire-schemas/pull/193).

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
