### PR TITLE
Remove deprecated set-env command

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          echo "PYTHON_VERSION=cat .python-version)" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: |
-          echo "PYTHON_VERSION=python -c 'import platform; print(platform.python_version())')" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=$(python -c 'import platform; print(platform.python_version())')" >> $GITHUB_ENV
       - name: Install Pipenv
         run: pip install pipenv==2018.11.26
       - name: Cache virtualenv
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.14.1'
+          node-version: "12.14.1"
       - name: Get yarn cache
         id: get-yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -56,12 +56,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          echo "PYTHON_VERSION=cat .python-version)" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: |
-          echo "PYTHON_VERSION=python -c 'import platform; print(platform.python_version())')" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=$(python -c 'import platform; print(platform.python_version())')" >> $GITHUB_ENV
       - name: Install pipenv
         run: pip install pipenv==2018.11.26
       - name: Cache virtualenv
@@ -76,15 +76,15 @@ jobs:
       - name: Running unit tests
         run: make test
   docker-push:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
-        - name: Tag
-          run: echo "TAG=${{ github.event.pull_request.head.ref }}" > $GITHUB_ENV
-        - name: Build
-          run: docker build -t onsdigital/eq-questionnaire-validator:$TAG .
-        - name: Push
-          run: |
-            echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-            echo "Pushing with tag [$TAG]"
-            docker push onsdigital/eq-questionnaire-validator:$TAG
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tag
+        run: echo "TAG=${{ github.event.pull_request.head.ref }}" > $GITHUB_ENV
+      - name: Build
+        run: docker build -t onsdigital/eq-questionnaire-validator:$TAG .
+      - name: Push
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          echo "Pushing with tag [$TAG]"
+          docker push onsdigital/eq-questionnaire-validator:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          echo "::set-env name=PYTHON_VERSION::$(cat .python-version)"
+          echo "PYTHON_VERSION=cat .python-version)" >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: |
-          echo "::set-env name=PYTHON_VERSION::$(python -c 'import platform; print(platform.python_version())')"
+          echo "PYTHON_VERSION=python -c 'import platform; print(platform.python_version())')" >> $GITHUB_ENV
       - name: Install Pipenv
         run: pip install pipenv==2018.11.26
       - name: Cache virtualenv
@@ -56,12 +56,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          echo "::set-env name=PYTHON_VERSION::$(cat .python-version)"
+          echo "PYTHON_VERSION=cat .python-version)" >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: |
-          echo "::set-env name=PYTHON_VERSION::$(python -c 'import platform; print(platform.python_version())')"
+          echo "PYTHON_VERSION=python -c 'import platform; print(platform.python_version())')" >> $GITHUB_ENV
       - name: Install pipenv
         run: pip install pipenv==2018.11.26
       - name: Cache virtualenv
@@ -80,7 +80,7 @@ jobs:
       steps:
         - uses: actions/checkout@v2
         - name: Tag
-          run: echo "::set-env name=TAG::${{ github.event.pull_request.head.ref }}"
+          run: echo "TAG=${{ github.event.pull_request.head.ref }}" > $GITHUB_ENV
         - name: Build
           run: docker build -t onsdigital/eq-questionnaire-validator:$TAG .
         - name: Push


### PR DESCRIPTION
### PR Context
Remove deprecated set-env command from GitHub actions workflows

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
