### PR TITLE
Update view_submitted_response to view_response

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -144,7 +144,7 @@
           "type": "boolean",
           "description": "A flag that is used to determine if a feedback is available on questionnaire completion"
         },
-        "view_submitted_response": {
+        "view_response": {
           "type": "boolean",
           "description": "A flag that is used to determine if the users response is viewable after submission"
         }

--- a/tests/schemas/valid/test_submission_params.json
+++ b/tests/schemas/valid/test_submission_params.json
@@ -28,7 +28,7 @@
     "warning": "Submission warning",
     "confirmation_email": true,
     "feedback": true,
-    "view_submitted_response": true
+    "view_response": true
   },
   "questionnaire_flow": {
     "type": "Linear",


### PR DESCRIPTION
### PR Context
Due to the name of the parent container (submission) it was decided to update view_submitted_response to view_response
### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
