### PR TITLE
Add post submission guidance property

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -152,6 +152,23 @@
       "additionalProperties": false,
       "minProperties": 1
     },
+    "post_submission": {
+      "type": "object",
+      "properties": {
+        "guidance": {
+          "description": "Guidance displayed after the questionnaire is submitted.",
+          "type": "object",
+          "properties": {
+            "contents": {
+              "$ref": "https://eq.ons.gov.uk/common_definitions.json#/contents"
+            }
+          },
+          "required": ["contents"]
+        }
+      },
+      "additionalProperties": false,
+      "minProperties": 1
+    },
     "individual_response": {
       "$ref": "https://eq.ons.gov.uk/individual_response/definitions.json#/individual_response"
     },

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -163,7 +163,8 @@
               "$ref": "https://eq.ons.gov.uk/common_definitions.json#/contents"
             }
           },
-          "required": ["contents"]
+          "required": ["contents"],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false,

--- a/tests/schemas/valid/test_post_submission_params.json
+++ b/tests/schemas/valid/test_post_submission_params.json
@@ -1,0 +1,82 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "001",
+  "title": "Test Post Submission Params",
+  "theme": "default",
+  "description": "A questionnaire to test post submission params",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "post_submission": {
+    "guidance": {
+      "contents": [
+        {
+          "description": "This survey was important."
+        },
+        {
+          "description": "<a href=''>Important link</a>"
+        }
+      ]
+    }
+  },
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {
+      "summary": {
+        "collapsible": false
+      }
+    }
+  },
+  "sections": [
+    {
+      "id": "section",
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "did-you-know",
+              "question": {
+                "answers": [
+                  {
+                    "id": "answer",
+                    "mandatory": false,
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ],
+                    "type": "Radio"
+                  }
+                ],
+                "id": "question",
+                "title": "Did you know this schema is testing post submission params?",
+                "type": "General"
+              },
+              "type": "Question"
+            }
+          ],
+          "id": "group"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### PR Context

Adds a new `post_submission` property at the top-level. For now this contains a `guidance` property that allows for custom guidance to be displayed post submission.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
