### PR TITLE
Rationalise top-level submission property

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -135,18 +135,6 @@
         "warning": {
           "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
           "description": "The warning when the questionnaire is complete."
-        },
-        "confirmation_email": {
-          "type": "boolean",
-          "description": "A flag that is used to determine if an email confirmation is available on questionnaire completion"
-        },
-        "feedback": {
-          "type": "boolean",
-          "description": "A flag that is used to determine if a feedback is available on questionnaire completion"
-        },
-        "view_response": {
-          "type": "boolean",
-          "description": "A flag that is used to determine if the users response is viewable after submission"
         }
       },
       "additionalProperties": false,
@@ -165,6 +153,18 @@
           },
           "required": ["contents"],
           "additionalProperties": false
+        },
+        "confirmation_email": {
+          "type": "boolean",
+          "description": "A flag that is used to determine if an email confirmation is available on questionnaire completion"
+        },
+        "feedback": {
+          "type": "boolean",
+          "description": "A flag that is used to determine if a feedback is available on questionnaire completion"
+        },
+        "view_response": {
+          "type": "boolean",
+          "description": "A flag that is used to determine if the users response is viewable after submission"
         }
       },
       "additionalProperties": false,

--- a/tests/schemas/valid/test_post_submission_params.json
+++ b/tests/schemas/valid/test_post_submission_params.json
@@ -31,7 +31,10 @@
           "description": "<a href=''>Important link</a>"
         }
       ]
-    }
+    },
+    "confirmation_email": true,
+    "feedback": true,
+    "view_response": true
   },
   "questionnaire_flow": {
     "type": "Linear",

--- a/tests/schemas/valid/test_submission_params.json
+++ b/tests/schemas/valid/test_submission_params.json
@@ -25,10 +25,7 @@
     "button": "Submission button text",
     "guidance": "Submission guidance",
     "title": "Submission title",
-    "warning": "Submission warning",
-    "confirmation_email": true,
-    "feedback": true,
-    "view_response": true
+    "warning": "Submission warning"
   },
   "questionnaire_flow": {
     "type": "Linear",


### PR DESCRIPTION
### PR Context

Updated the structure of the top level `submission` into two keys:
```json
"submission": {
    "button": "Submission button text",
    "guidance": "Submission guidance",
    "title": "Submission title",
    "warning": "Submission warning",
},
"post_submission": {
    "guidance": {},
    "confirmation_email": true,
    "feedback": true,
    "view_response": true
},
```

- `submission` is for content on the submit page. 
- `post_submission` for anything after the submit page.

Ensure the changes make sense.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
