### PR TITLE
Remove skip conditions from question properties

### DIFF
--- a/schemas/questions/types/calculated.json
+++ b/schemas/questions/types/calculated.json
@@ -25,9 +25,6 @@
       "guidance": {
         "$ref": "https://eq.ons.gov.uk/questions/definitions.json#/question_guidance"
       },
-      "skip_conditions": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/skip_conditions"
-      },
       "type": {
         "type": "string",
         "enum": ["Calculated"]

--- a/schemas/questions/types/date_range.json
+++ b/schemas/questions/types/date_range.json
@@ -25,9 +25,6 @@
       "guidance": {
         "$ref": "https://eq.ons.gov.uk/questions/definitions.json#/question_guidance"
       },
-      "skip_conditions": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/skip_conditions"
-      },
       "type": {
         "type": "string",
         "enum": ["DateRange"]

--- a/schemas/questions/types/general.json
+++ b/schemas/questions/types/general.json
@@ -31,9 +31,6 @@
       "summary": {
         "$ref": "https://eq.ons.gov.uk/questions/definitions.json#/summary"
       },
-      "skip_conditions": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/skip_conditions"
-      },
       "type": {
         "type": "string",
         "enum": ["General"]

--- a/schemas/questions/types/mutually_exclusive.json
+++ b/schemas/questions/types/mutually_exclusive.json
@@ -28,9 +28,6 @@
       "guidance": {
         "$ref": "https://eq.ons.gov.uk/questions/definitions.json#/question_guidance"
       },
-      "skip_conditions": {
-        "$ref": "https://eq.ons.gov.uk/common_definitions.json#/skip_conditions"
-      },
       "type": {
         "type": "string",
         "enum": ["MutuallyExclusive"]


### PR DESCRIPTION
### PR Context
This removes question definitions skip condition property which is not longer supported. Skip conditions inside the question are no longer supported and any remaining schemas should be removed.

How to review
Check if all the question types have skip conditions removed. Check if this branch of validator works correctly with [this PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/688).


### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
