### PR TITLE
Check non existent answer, list, metadata ids

### DIFF
--- a/app/validators/routing/new_when_rule_validator.py
+++ b/app/validators/routing/new_when_rule_validator.py
@@ -44,13 +44,6 @@ ALL_OPERATORS = (
     LOGIC_OPERATORS + COMPARISON_OPERATORS + ARRAY_OPERATORS + VALUE_OPERATORS
 )
 
-source_validation = {
-    "answers": "test",
-    "list": "list",
-    "location": "location",
-    "metadata": "metadata",
-}
-
 
 class NewWhenRuleValidator(Validator):
     OPERATOR_ARGUMENT_TYPE_MISMATCH = "Argument types don't match"
@@ -243,26 +236,6 @@ class NewWhenRuleValidator(Validator):
             if argument_position == 0:
                 return [TYPE_NUMBER, TYPE_STRING]
             return [TYPE_ARRAY]
-
-    def validate_list_name_in_when_rule(self, list_name):
-        """
-        Validate that the list referenced in the when rule is defined in the schema
-        """
-
-        if list_name not in self.questionnaire_schema.list_names:
-            self.add_error(self.LIST_REFERENCE_INVALID, list_name=list_name)
-
-    def validate_answer_ids_present_in_schema(self, answer_identifier):
-        """
-        Validates that any ids that are referenced within the when rule are present within the schema.  This prevents
-        writing when conditions against id's that don't exist.
-        :return: list of dictionaries containing error messages, otherwise it returns an empty list
-        """
-
-        if answer_identifier not in self.questionnaire_schema.answers_with_context:
-            self.add_error(self.NON_EXISTENT_WHEN_KEY, answer_id=answer_identifier)
-            return False
-        return True
 
     def is_source_id_valid(self, rule):
         """

--- a/app/validators/routing/new_when_rule_validator.py
+++ b/app/validators/routing/new_when_rule_validator.py
@@ -261,7 +261,7 @@ class NewWhenRuleValidator(Validator):
 
     def check_argument_source_exists(self, argument):
         """
-        Checks argument id is present in Questionnair schema
+        Checks argument id is present in Questionnaire schema
         :param argument: dict : argument identifier and source
         if identifier is not present in schema, error is added to the self.error dict
         """

--- a/tests/validators/routing/conftest.py
+++ b/tests/validators/routing/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from app.validators.routing.new_when_rule_validator import NewWhenRuleValidator
+
+
+@pytest.fixture(scope="function")
+def mock_is_source_id_valid(monkeypatch):
+    def mock_return(*args):  # pylint: disable=unused-argument
+        # return true to skip id name validations within schema
+        return True
+
+    monkeypatch.setattr(NewWhenRuleValidator, "is_source_id_valid", mock_return)

--- a/tests/validators/routing/conftest.py
+++ b/tests/validators/routing/conftest.py
@@ -9,4 +9,4 @@ def mock_is_source_id_valid(monkeypatch):
         # return true to skip id name validations within schema
         return True
 
-    monkeypatch.setattr(NewWhenRuleValidator, "is_source_id_valid", mock_return)
+    monkeypatch.setattr(NewWhenRuleValidator, "is_source_identifier_valid", mock_return)

--- a/tests/validators/routing/test_new_when_rule_validator.py
+++ b/tests/validators/routing/test_new_when_rule_validator.py
@@ -330,6 +330,7 @@ def test_validate_options_multiple_errors():
     assert validator.errors == expected_errors
 
 
+@pytest.mark.usefixtures("mock_is_source_id_valid")
 @pytest.mark.parametrize(
     "operator_name, first_argument, second_argument",
     [
@@ -354,9 +355,7 @@ def test_validate_options_multiple_errors():
         ("==", {"source": "location", "identifier": "list_item_id"}, "list-item-id"),
     ],
 )
-def test_validate_value_sources(
-    operator_name, first_argument, second_argument, mock_is_source_id_valid
-):  # pylint: disable=unused-argument
+def test_validate_value_sources(operator_name, first_argument, second_argument):
     rule = {operator_name: [first_argument, second_argument]}
     questionnaire_schema = QuestionnaireSchema({})
     questionnaire_schema.answers_with_context = {

--- a/tests/validators/routing/test_new_when_rule_validator.py
+++ b/tests/validators/routing/test_new_when_rule_validator.py
@@ -453,7 +453,7 @@ def test_list_name_not_present_in_schema_returns_error():
     validator = get_validator(rule, questionnaire_schema)
     validator.validate()
     expected_error = {
-        "message": validator.LIST_REFERENCE_INVALID,
+        "message": validator.INVALID_LIST_REFERENCE,
         "origin_id": ORIGIN_ID,
         "list_id": "non_existent_list",
     }
@@ -469,7 +469,7 @@ def test_answer_name_not_present_in_schema_returns_error():
     validator = get_validator(rule, questionnaire_schema)
     validator.validate()
     expected_error = {
-        "message": validator.NON_EXISTENT_WHEN_KEY,
+        "message": validator.INVALID_ANSWERS_REFERENCE,
         "origin_id": ORIGIN_ID,
         "answers_id": "non-existent-answer",
     }
@@ -488,7 +488,7 @@ def test_metadata_name_not_present_in_schema_returns_error():
     validator = get_validator(rule, questionnaire_schema)
     validator.validate()
     expected_error = {
-        "message": validator.METADATA_REFERENCE_INVALID,
+        "message": validator.INVALID_METADATA_REFERENCE,
         "origin_id": ORIGIN_ID,
         "metadata_id": "non-existent-metadata",
     }

--- a/tests/validators/routing/test_new_when_rule_validator.py
+++ b/tests/validators/routing/test_new_when_rule_validator.py
@@ -456,7 +456,7 @@ def test_list_name_not_present_in_schema_returns_error():
     expected_error = {
         "message": validator.LIST_REFERENCE_INVALID,
         "origin_id": ORIGIN_ID,
-        "list_name": "non_existent_list",
+        "list_id": "non_existent_list",
     }
     assert validator.errors[0] == expected_error
 
@@ -472,6 +472,25 @@ def test_answer_name_not_present_in_schema_returns_error():
     expected_error = {
         "message": validator.NON_EXISTENT_WHEN_KEY,
         "origin_id": ORIGIN_ID,
-        "answer_id": "non-existent-answer",
+        "answers_id": "non-existent-answer",
+    }
+    assert validator.errors[0] == expected_error
+
+
+def test_metadata_name_not_present_in_schema_returns_error():
+    rule = {
+        ">": [
+            {"date": [{"source": "metadata", "identifier": "non-existent-metadata"}]},
+            "test",
+        ]
+    }
+    questionnaire_schema = QuestionnaireSchema({})
+    questionnaire_schema.metadata_ids = ["existing-metdata", "some-other-metadata"]
+    validator = get_validator(rule, questionnaire_schema)
+    validator.validate()
+    expected_error = {
+        "message": validator.METADATA_REFERENCE_INVALID,
+        "origin_id": ORIGIN_ID,
+        "metadata_id": "non-existent-metadata",
     }
     assert validator.errors[0] == expected_error


### PR DESCRIPTION
### PR Context
This checks for any non existent `answer`,`metadata` or `list` names within the schema. if they are not present , an appropriate error is sent to the client.

out of scope : source as `location` , `response_metadata `? . there are no new `when` rule schemas for that.
### How to test
Take any schema with new `When` rule , try to update the `identifier` with any name which is not present in schema and validate with this change. One can use combination of **source** as **answer**,**metadata** or **list**

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
