### PR TITLE
Add new rules design for section enabled rules

### DIFF
--- a/app/validators/sections/section_validator.py
+++ b/app/validators/sections/section_validator.py
@@ -44,16 +44,16 @@ class SectionValidator(Validator):
     def validate_section_enabled(self):
         section_enabled = self.section.get("enabled", None)
 
-        if section_enabled and isinstance(section_enabled, list):
-            for enabled in self.section.get("enabled"):
+        if isinstance(section_enabled, list):
+            for enabled in section_enabled:
                 when = enabled["when"]
                 when_validator = WhenRuleValidator(
                     when, self.section["id"], self.questionnaire_schema
                 )
                 self.errors += when_validator.validate()
 
-        if section_enabled and isinstance(section_enabled, dict):
-            when = self.section.get("enabled")["when"]
+        if isinstance(section_enabled, dict):
+            when = section_enabled["when"]
             when_validator = NewWhenRuleValidator(
                 when, self.section["id"], self.questionnaire_schema
             )

--- a/app/validators/sections/section_validator.py
+++ b/app/validators/sections/section_validator.py
@@ -25,6 +25,7 @@ class SectionValidator(Validator):
         self.validate_summary()
         self.validate_groups()
         self.validate_value_sources()
+        self.validate_section_enabled()
         return self.errors
 
     def validate_repeat(self):
@@ -39,6 +40,24 @@ class SectionValidator(Validator):
         if section_summary:
             for item in section_summary.get("items", []):
                 self.validate_list_exists(item.get("for_list"))
+
+    def validate_section_enabled(self):
+        section_enabled = self.section.get("enabled", None)
+
+        if section_enabled and isinstance(section_enabled, list):
+            for enabled in self.section.get("enabled"):
+                when = enabled["when"]
+                when_validator = WhenRuleValidator(
+                    when, self.section["id"], self.questionnaire_schema
+                )
+                self.errors += when_validator.validate()
+
+        if section_enabled and isinstance(section_enabled, dict):
+            when = self.section.get("enabled")["when"]
+            when_validator = NewWhenRuleValidator(
+                when, self.section["id"], self.questionnaire_schema
+            )
+            self.errors += when_validator.validate()
 
     def validate_list_exists(self, list_name):
         if list_name not in self.questionnaire_schema.list_names:

--- a/app/validators/sections/section_validator.py
+++ b/app/validators/sections/section_validator.py
@@ -52,7 +52,7 @@ class SectionValidator(Validator):
                 )
                 self.errors += when_validator.validate()
 
-        if isinstance(section_enabled, dict):
+        elif isinstance(section_enabled, dict):
             when = section_enabled["when"]
             when_validator = NewWhenRuleValidator(
                 when, self.section["id"], self.questionnaire_schema

--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -117,6 +117,33 @@
       }
     ]
   },
+  "original_section_enabled": {
+    "description": "When the value evaluates to false, this section will not be included in the questionnaire. When the enabled key is not present, the default value is true. By adding more than one `when` element it will evaluate as an or rule.",
+    "type": "array",
+    "minItems": 1,
+    "uniqueItems": true,
+    "items": {
+      "type": "object",
+      "properties": {
+        "when": {
+          "$ref": "https://eq.ons.gov.uk/when_rule/definitions.json#/when"
+        }
+      },
+      "additionalProperties": false
+    },
+    "required": ["when"]
+  },
+  "new_section_enabled": {
+    "description": "When the value evaluates to false, this section will not be included in the questionnaire. When the enabled key is not present, the default value is true. By adding more than one `when` element it will evaluate as an or rule.",
+    "type": "object",
+    "properties": {
+      "when": {
+        "$ref": "https://eq.ons.gov.uk/rules/rule.json"
+      }
+    },
+    "additionalProperties": false,
+    "required": ["when"]
+  },
   "messages": {
     "type": "object",
     "description": "These messages override the standard error messages.",

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -322,20 +322,14 @@
             }
           },
           "enabled": {
-            "description": "When the value evaluates to false, this section will not be included in the questionnaire. When the enabled key is not present, the default value is true. By adding more than one `when` element it will evaluate as an or rule.",
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-              "type": "object",
-              "properties": {
-                "when": {
-                  "$ref": "https://eq.ons.gov.uk/when_rule/definitions.json#/when"
-                }
+            "oneOf": [
+              {
+                "$ref": "https://eq.ons.gov.uk/common_definitions.json#/original_section_enabled"
               },
-              "additionalProperties": false
-            },
-            "required": ["when"]
+              {
+                "$ref": "https://eq.ons.gov.uk/common_definitions.json#/new_section_enabled"
+              }
+            ]
           }
         },
         "required": ["id", "groups"]

--- a/tests/schemas/valid/test_new_section_enabled.json
+++ b/tests/schemas/valid/test_new_section_enabled.json
@@ -1,0 +1,108 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test Section Enabled",
+  "theme": "default",
+  "description": "A questionnaire to demo new section enabled key usage",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {
+      "summary": {
+        "collapsible": false
+      }
+    }
+  },
+  "sections": [
+    {
+      "id": "section-1",
+      "title": "Section 1",
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "section-1-block",
+              "type": "Question",
+              "question": {
+                "answers": [
+                  {
+                    "id": "section-1-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ],
+                    "type": "Checkbox"
+                  }
+                ],
+                "description": ["Choose ‘Yes’ to enable section 2."],
+                "id": "section-1-question",
+                "title": "Do you want to enable section 2?",
+                "type": "General"
+              }
+            }
+          ],
+          "id": "section-1-group",
+          "title": "Section 1"
+        }
+      ]
+    },
+    {
+      "id": "section-2",
+      "title": "Section 2",
+      "enabled": {
+        "when": {
+          "in": [
+            "Yes",
+            {
+              "source": "answers",
+              "identifier": "section-1-answer"
+            }
+          ]
+        }
+      },
+      "groups": [
+        {
+          "blocks": [
+            {
+              "id": "section-2-interstitial",
+              "content": {
+                "title": "Section 2 interstitial",
+                "contents": [
+                  {
+                    "description": "You should be only able to see this interstitial page if you chose ‘Yes’ in the previous question."
+                  }
+                ]
+              },
+              "type": "Interstitial"
+            }
+          ],
+          "id": "section-2-group",
+          "title": "Section 2"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### PR Context
This adds new rules engine validation support to section enabled schema element (as well as missing validation of the old style rules for section enabled). Validator is currently not failing on incorrect referenced answer when used in section enabled "when" rule, fix being worked on, check this card: https://trello.com/c/irPw0tnc/4936-update-newwhenrulevalidator-to-check-for-non-existing-references. Test schema with valid section enabled was added.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
