### PR TITLE
Add support for dynamic answer options

### DIFF
--- a/app/validators/answers/answer_validator.py
+++ b/app/validators/answers/answer_validator.py
@@ -5,4 +5,6 @@ class AnswerValidator(Validator):
     def __init__(self, schema_element):
         super().__init__(schema_element)
         self.answer = schema_element
-        self.context["answer_id"] = self.answer["id"]
+        self.answer_id = self.answer["id"]
+        self.answer_type = self.answer["type"]
+        self.context["answer_id"] = self.answer_id

--- a/app/validators/schema_validator.py
+++ b/app/validators/schema_validator.py
@@ -43,7 +43,11 @@ class SchemaValidator(Validator):
         except ValidationError as e:
             match = best_match([e])
             path = "/".join(str(path_element) for path_element in e.path)
-            self.add_error(match.message, verbose=e.message, pointer=f"/{path}")
+            error = {
+                "reason": e.message.replace(str(e.instance), "").strip(),
+                "json": e.instance,
+            }
+            self.add_error(match.message, verbose=error, pointer=f"/{path}")
         except SchemaError as e:
             self.add_error(e)
         return self.errors

--- a/schemas/answers/checkbox.json
+++ b/schemas/answers/checkbox.json
@@ -33,15 +33,11 @@
         "type": "string",
         "enum": ["Checkbox"]
       },
+      "dynamic_options": {
+        "$ref": "definitions.json#/dynamic_options"
+      },
       "options": {
-        "allOf": [
-          {
-            "$ref": "definitions.json#/options"
-          },
-          {
-            "minItems": 1
-          }
-        ]
+        "$ref": "definitions.json#/options"
       },
       "mandatory": {
         "type": "boolean"
@@ -58,6 +54,14 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "mandatory", "options"]
+    "required": ["id", "type", "mandatory"],
+    "anyOf": [
+      {
+        "required": ["options"]
+      },
+      {
+        "required": ["dynamic_options"]
+      }
+    ]
   }
 }

--- a/schemas/answers/definitions.json
+++ b/schemas/answers/definitions.json
@@ -59,6 +59,24 @@
       "required": ["label", "value"]
     }
   },
+  "dynamic_options": {
+    "type": "object",
+    "properties": {
+      "values": {
+        "oneOf": [
+          { "$ref": "https://eq.ons.gov.uk/rules/operators/value/map.json" },
+          {
+            "$ref": "https://eq.ons.gov.uk/value_sources.json#/any_value_source_except_location"
+          }
+        ]
+      },
+      "transform": {
+        "$ref": "https://eq.ons.gov.uk/rules/definitions.json#/non_array_value_operators"
+      }
+    },
+    "additionalProperties": false,
+    "required": ["values", "transform"]
+  },
   "min_value": {
     "type": "object",
     "properties": {

--- a/schemas/answers/dropdown.json
+++ b/schemas/answers/dropdown.json
@@ -30,15 +30,11 @@
       "description": {
         "$ref": "https://eq.ons.gov.uk/string_interpolation/definitions.json#/string_with_placeholders"
       },
+      "dynamic_options": {
+        "$ref": "definitions.json#/dynamic_options"
+      },
       "options": {
-        "allOf": [
-          {
-            "$ref": "definitions.json#/options"
-          },
-          {
-            "minItems": 2
-          }
-        ]
+        "$ref": "definitions.json#/options"
       },
       "validation": {
         "type": "object",
@@ -52,6 +48,14 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "mandatory", "label", "options"]
+    "required": ["id", "type", "mandatory", "label"],
+    "anyOf": [
+      {
+        "required": ["options"]
+      },
+      {
+        "required": ["dynamic_options"]
+      }
+    ]
   }
 }

--- a/schemas/answers/radio.json
+++ b/schemas/answers/radio.json
@@ -27,15 +27,11 @@
         "type": "string",
         "enum": ["Radio"]
       },
+      "dynamic_options": {
+        "$ref": "definitions.json#/dynamic_options"
+      },
       "options": {
-        "allOf": [
-          {
-            "$ref": "definitions.json#/options"
-          },
-          {
-            "minItems": 2
-          }
-        ]
+        "$ref": "definitions.json#/options"
       },
       "mandatory": {
         "type": "boolean"
@@ -56,7 +52,15 @@
       }
     },
     "additionalProperties": false,
-    "required": ["id", "type", "mandatory", "options"],
+    "required": ["id", "type", "mandatory"],
+    "anyOf": [
+      {
+        "required": ["options"]
+      },
+      {
+        "required": ["dynamic_options"]
+      }
+    ],
     "if": {
       "properties": { "mandatory": { "const": true } }
     },

--- a/schemas/rules/definitions.json
+++ b/schemas/rules/definitions.json
@@ -44,6 +44,19 @@
       { "$ref": "https://eq.ons.gov.uk/rules/operators/value/map.json" }
     ]
   },
+  "non_array_value_operators": {
+    "description": "All operators that resolve to a value",
+    "oneOf": [
+      { "$ref": "https://eq.ons.gov.uk/rules/operators/value/count.json" },
+      { "$ref": "https://eq.ons.gov.uk/rules/operators/value/date.json" },
+      {
+        "$ref": "https://eq.ons.gov.uk/rules/operators/value/format-date.json"
+      },
+      {
+        "$ref": "https://eq.ons.gov.uk/rules/operators/value/option-label-from-value.json"
+      }
+    ]
+  },
   "list_value_operators": {
     "description": "All operators that resolve to a list of values",
     "oneOf": [

--- a/schemas/rules/definitions.json
+++ b/schemas/rules/definitions.json
@@ -41,11 +41,17 @@
       {
         "$ref": "https://eq.ons.gov.uk/rules/operators/value/format-date.json"
       },
-      { "$ref": "https://eq.ons.gov.uk/rules/operators/value/map.json" }
+      { "$ref": "https://eq.ons.gov.uk/rules/operators/value/map.json" },
+      {
+        "$ref": "https://eq.ons.gov.uk/rules/operators/value/option-label-from-value.json"
+      },
+      {
+        "$ref": "https://eq.ons.gov.uk/rules/operators/value/concat.json"
+      }
     ]
   },
   "non_array_value_operators": {
-    "description": "All operators that resolve to a value",
+    "description": "All operators that resolve to a non-array value",
     "oneOf": [
       { "$ref": "https://eq.ons.gov.uk/rules/operators/value/count.json" },
       { "$ref": "https://eq.ons.gov.uk/rules/operators/value/date.json" },
@@ -54,6 +60,9 @@
       },
       {
         "$ref": "https://eq.ons.gov.uk/rules/operators/value/option-label-from-value.json"
+      },
+      {
+        "$ref": "https://eq.ons.gov.uk/rules/operators/value/concat.json"
       }
     ]
   },

--- a/schemas/rules/non_array_value_rule.json
+++ b/schemas/rules/non_array_value_rule.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://eq.ons.gov.uk/rules/non_array_value_rule.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "Top level non array value operator rule",
+  "$ref": "https://eq.ons.gov.uk/rules/definitions.json#/non_array_value_operators"
+}

--- a/schemas/rules/operators/value/concat.json
+++ b/schemas/rules/operators/value/concat.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://eq.ons.gov.uk/rules/operators/value/concat.json",
+  "description": "Joins a list of strings together with a delimiter. Takes two arguments, the list of strings and the delimiter.",
+  "type": "object",
+  "properties": {
+    "concat": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "description": "A list of values to concatenate",
+          "items": [
+            {
+              "items": {
+                "$ref": "https://eq.ons.gov.uk/value_sources.json#/any_value_source"
+              }
+            }
+          ]
+        },
+        {
+          "description": "The delimiter to use, common ones are ' ' for names and ', ' for addresses.",
+          "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+        }
+      ]
+    }
+  },
+  "required": ["concat"],
+  "additionalProperties": false
+}

--- a/schemas/rules/operators/value/option-label-from-value.json
+++ b/schemas/rules/operators/value/option-label-from-value.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://eq.ons.gov.uk/rules/operators/value/option-label-from-value.json",
+  "description": "Get the label of an answer option based on its value. Takes two arguments, the option value and the answer id",
+  "type": "object",
+  "properties": {
+    "option-label-from-value": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [
+        {
+          "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+        },
+        {
+          "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
+        }
+      ]
+    }
+  },
+  "required": ["option-label-from-value"],
+  "additionalProperties": false
+}

--- a/schemas/rules/operators/value/option-label-from-value.json
+++ b/schemas/rules/operators/value/option-label-from-value.json
@@ -10,10 +10,12 @@
       "maxItems": 2,
       "items": [
         {
-          "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+          "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+          "description": "The value of the option"
         },
         {
-          "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier"
+          "$ref": "https://eq.ons.gov.uk/common_definitions.json#/identifier",
+          "description": "The answer id to which the option belongs to"
         }
       ]
     }

--- a/schemas/value_sources.json
+++ b/schemas/value_sources.json
@@ -106,5 +106,22 @@
         "$ref": "https://eq.ons.gov.uk/value_sources.json#/location_value_source"
       }
     ]
+  },
+  "any_value_source_except_location": {
+    "description": "Any value source",
+    "anyOf": [
+      {
+        "$ref": "https://eq.ons.gov.uk/value_sources.json#/answer_value_source"
+      },
+      {
+        "$ref": "https://eq.ons.gov.uk/value_sources.json#/metadata_value_source"
+      },
+      {
+        "$ref": "https://eq.ons.gov.uk/value_sources.json#/response_metadata_value_source"
+      },
+      {
+        "$ref": "https://eq.ons.gov.uk/value_sources.json#/list_value_source"
+      }
+    ]
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def find_all_json_files(folder_name):
     ]
 
 
-def get_mock_schema(questionnaire_schema, answers_with_context):
+def get_mock_schema(questionnaire_schema=None, answers_with_context=None):
     if not questionnaire_schema:
         questionnaire_schema = QuestionnaireSchema({})
 

--- a/tests/schemas/rules/value/map.json
+++ b/tests/schemas/rules/value/map.json
@@ -49,5 +49,29 @@
         }
       ]
     }
+  },
+  {
+    "description": "Map over a list of dates using `date-range` operator using a dynamic date source `now`",
+    "rule": {
+      "map": [
+        {
+          "format-date": ["self", "yyyy-MM-dd"]
+        },
+        {
+          "date-range": [
+            {
+              "date": [
+                "now",
+                {
+                  "days": 7,
+                  "day_of_week": "MONDAY"
+                }
+              ]
+            },
+            7
+          ]
+        }
+      ]
+    }
   }
 ]

--- a/tests/schemas/rules/value/option-label-from-value.json
+++ b/tests/schemas/rules/value/option-label-from-value.json
@@ -1,0 +1,8 @@
+[
+  {
+    "description": "Get the label of an option using its value and answer id",
+    "rule": {
+      "option-label-from-value": ["Yes", "checkbox-answer"]
+    }
+  }
+]

--- a/tests/schemas/valid/test_dynamic_answer_options_checkbox_driven.json
+++ b/tests/schemas/valid/test_dynamic_answer_options_checkbox_driven.json
@@ -1,0 +1,200 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Dynamic answer options",
+  "theme": "default",
+  "description": "A questionnaire to demo dynamic answer options",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {
+      "summary": {
+        "collapsible": false
+      }
+    }
+  },
+  "sections": [
+    {
+      "id": "default-section",
+      "groups": [
+        {
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "mandatory-checkbox",
+              "question": {
+                "id": "mandatory-checkbox-question",
+                "title": "What extra toppings would you like?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "mandatory-checkbox-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "None",
+                        "value": "None"
+                      },
+                      {
+                        "label": "Cheese",
+                        "value": "Cheese"
+                      },
+                      {
+                        "label": "Ham",
+                        "value": "Ham"
+                      },
+                      {
+                        "label": "Pineapple",
+                        "value": "Pineapple"
+                      },
+                      {
+                        "label": "Tuna",
+                        "value": "Tuna"
+                      },
+                      {
+                        "label": "Pepperoni",
+                        "value": "Pepperoni"
+                      },
+                      {
+                        "label": "Other",
+                        "value": "Other",
+                        "description": "Choose any other topping",
+                        "detail_answer": {
+                          "mandatory": false,
+                          "id": "other-answer-mandatory",
+                          "label": "Please specify other",
+                          "type": "TextField"
+                        }
+                      }
+                    ],
+                    "type": "Checkbox"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "checkbox-with-dynamic-options",
+              "question": {
+                "id": "checkbox-with-dynamic-options-question",
+                "title": "Which one is your favourite?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-checkbox-answer",
+                    "mandatory": true,
+                    "type": "Checkbox",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "answers",
+                        "identifier": "mandatory-checkbox-answer"
+                      },
+                      "transform": {
+                        "option-label-from-value": [
+                          "self",
+                          "mandatory-checkbox-answer"
+                        ]
+                      }
+                    },
+                    "options": [
+                      {
+                        "label": "I don’t have a favourite",
+                        "value": "I don’t have a favourite"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "radio-with-dynamic-options",
+              "question": {
+                "id": "radio-with-dynamic-options-question",
+                "title": "Which one is your favourite?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-radio-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "answers",
+                        "identifier": "mandatory-checkbox-answer"
+                      },
+                      "transform": {
+                        "option-label-from-value": [
+                          "self",
+                          "mandatory-checkbox-answer"
+                        ]
+                      }
+                    },
+                    "options": [
+                      {
+                        "label": "I don’t have a favourite",
+                        "value": "I don’t have a favourite"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "dropdown-with-dynamic-options",
+              "question": {
+                "id": "dropdown-with-dynamic-options-question",
+                "title": "Which one is your favourite?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-dropdown-answer",
+                    "mandatory": true,
+                    "type": "Dropdown",
+                    "label": "Select an option",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "answers",
+                        "identifier": "mandatory-checkbox-answer"
+                      },
+                      "transform": {
+                        "option-label-from-value": [
+                          "self",
+                          "mandatory-checkbox-answer"
+                        ]
+                      }
+                    },
+                    "options": [
+                      {
+                        "label": "I don’t have a favourite",
+                        "value": "I don’t have a favourite"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "id": "dynamic-answer-options-group"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_dynamic_answer_options_dynamic_date_driven.json
+++ b/tests/schemas/valid/test_dynamic_answer_options_dynamic_date_driven.json
@@ -4,9 +4,9 @@
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",
-  "title": "Dynamic answer options driven by a Checkbox",
+  "title": "Dynamic answer options driven by a dynamic date",
   "theme": "default",
-  "description": "A questionnaire to demo dynamic answer options driven by a Checkbox",
+  "description": "A questionnaire to demo dynamic answer options driven by a dynamic date",
   "metadata": [
     {
       "name": "user_id",
@@ -37,59 +37,6 @@
           "blocks": [
             {
               "type": "Question",
-              "id": "mandatory-checkbox",
-              "question": {
-                "id": "mandatory-checkbox-question",
-                "title": "What extra toppings would you like?",
-                "type": "General",
-                "answers": [
-                  {
-                    "id": "mandatory-checkbox-answer",
-                    "mandatory": true,
-                    "options": [
-                      {
-                        "label": "None",
-                        "value": "None"
-                      },
-                      {
-                        "label": "Cheese",
-                        "value": "Cheese"
-                      },
-                      {
-                        "label": "Ham",
-                        "value": "Ham"
-                      },
-                      {
-                        "label": "Pineapple",
-                        "value": "Pineapple"
-                      },
-                      {
-                        "label": "Tuna",
-                        "value": "Tuna"
-                      },
-                      {
-                        "label": "Pepperoni",
-                        "value": "Pepperoni"
-                      },
-                      {
-                        "label": "Other",
-                        "value": "Other",
-                        "description": "Choose any other topping",
-                        "detail_answer": {
-                          "mandatory": false,
-                          "id": "other-answer-mandatory",
-                          "label": "Please specify other",
-                          "type": "TextField"
-                        }
-                      }
-                    ],
-                    "type": "Checkbox"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "Question",
               "id": "checkbox-with-dynamic-options",
               "question": {
                 "id": "checkbox-with-dynamic-options-question",
@@ -102,13 +49,35 @@
                     "type": "Checkbox",
                     "dynamic_options": {
                       "values": {
-                        "source": "answers",
-                        "identifier": "mandatory-checkbox-answer"
+                        "map": [
+                          {
+                            "format-date": ["self", "yyyy-MM-dd"]
+                          },
+                          {
+                            "date-range": [
+                              {
+                                "date": [
+                                  {
+                                    "source": "response_metadata",
+                                    "identifier": "started_at"
+                                  },
+                                  {
+                                    "days": -7,
+                                    "day_of_week": "MONDAY"
+                                  }
+                                ]
+                              },
+                              7
+                            ]
+                          }
+                        ]
                       },
                       "transform": {
-                        "option-label-from-value": [
-                          "self",
-                          "mandatory-checkbox-answer"
+                        "format-date": [
+                          {
+                            "date": ["self"]
+                          },
+                          "EEEE d MMMM yyyy"
                         ]
                       }
                     },
@@ -136,13 +105,35 @@
                     "type": "Radio",
                     "dynamic_options": {
                       "values": {
-                        "source": "answers",
-                        "identifier": "mandatory-checkbox-answer"
+                        "map": [
+                          {
+                            "format-date": ["self", "yyyy-MM-dd"]
+                          },
+                          {
+                            "date-range": [
+                              {
+                                "date": [
+                                  {
+                                    "source": "response_metadata",
+                                    "identifier": "started_at"
+                                  },
+                                  {
+                                    "days": -7,
+                                    "day_of_week": "MONDAY"
+                                  }
+                                ]
+                              },
+                              7
+                            ]
+                          }
+                        ]
                       },
                       "transform": {
-                        "option-label-from-value": [
-                          "self",
-                          "mandatory-checkbox-answer"
+                        "format-date": [
+                          {
+                            "date": ["self"]
+                          },
+                          "EEEE d MMMM yyyy"
                         ]
                       }
                     },
@@ -171,13 +162,35 @@
                     "label": "Select an option",
                     "dynamic_options": {
                       "values": {
-                        "source": "answers",
-                        "identifier": "mandatory-checkbox-answer"
+                        "map": [
+                          {
+                            "format-date": ["self", "yyyy-MM-dd"]
+                          },
+                          {
+                            "date-range": [
+                              {
+                                "date": [
+                                  {
+                                    "source": "response_metadata",
+                                    "identifier": "started_at"
+                                  },
+                                  {
+                                    "days": -7,
+                                    "day_of_week": "MONDAY"
+                                  }
+                                ]
+                              },
+                              7
+                            ]
+                          }
+                        ]
                       },
                       "transform": {
-                        "option-label-from-value": [
-                          "self",
-                          "mandatory-checkbox-answer"
+                        "format-date": [
+                          {
+                            "date": ["self"]
+                          },
+                          "EEEE d MMMM yyyy"
                         ]
                       }
                     },

--- a/tests/schemas/valid/test_dynamic_answer_options_list_collector_driven.json
+++ b/tests/schemas/valid/test_dynamic_answer_options_list_collector_driven.json
@@ -1,0 +1,315 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Dynamic answer options driven by a list collector",
+  "theme": "default",
+  "description": "A questionnaire to demo dynamic answer options driven by a list collector",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {
+      "summary": {
+        "collapsible": false
+      }
+    }
+  },
+  "sections": [
+    {
+      "id": "default-section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "List",
+          "blocks": [
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "for_list": "people",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Does anyone else live here?",
+                "answers": [
+                  {
+                    "id": "anyone-else",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-person",
+                "type": "ListAddQuestion",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-person",
+                "type": "ListEditQuestion",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-person",
+                "type": "ListRemoveQuestion",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this person?",
+                  "warning": "All of the information about this person will be deleted",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yeah",
+                          "value": "Yeah",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "Household members",
+                "item_title": {
+                  "text": "{person_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "first-name"
+                              },
+                              {
+                                "source": "answers",
+                                "identifier": "last-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "checkbox-with-dynamic-options",
+              "question": {
+                "id": "checkbox-with-dynamic-options-question",
+                "title": "Who is the home owner?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-checkbox-answer",
+                    "mandatory": true,
+                    "type": "Checkbox",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "list",
+                        "identifier": "people"
+                      },
+                      "transform": {
+                        "concat": [
+                          [
+                            {
+                              "source": "answers",
+                              "identifier": "first-name"
+                            },
+                            {
+                              "source": "answers",
+                              "identifier": "last-name"
+                            }
+                          ],
+                          " "
+                        ]
+                      }
+                    },
+                    "options": [
+                      {
+                        "label": "None of the above",
+                        "value": "None of the above"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "radio-with-dynamic-options",
+              "question": {
+                "id": "radio-with-dynamic-options-question",
+                "title": "Who is the home owner?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-radio-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "list",
+                        "identifier": "people"
+                      },
+                      "transform": {
+                        "concat": [
+                          [
+                            {
+                              "source": "answers",
+                              "identifier": "first-name"
+                            },
+                            {
+                              "source": "answers",
+                              "identifier": "last-name"
+                            }
+                          ],
+                          " "
+                        ]
+                      }
+                    },
+                    "options": [
+                      {
+                        "label": "None of the above",
+                        "value": "None of the above"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "dropdown-with-dynamic-options",
+              "question": {
+                "id": "dropdown-with-dynamic-options-question",
+                "title": "Who is the home owner?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-dropdown-answer",
+                    "mandatory": true,
+                    "type": "Dropdown",
+                    "label": "Select an option",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "list",
+                        "identifier": "people"
+                      },
+                      "transform": {
+                        "concat": [
+                          [
+                            {
+                              "source": "answers",
+                              "identifier": "first-name"
+                            },
+                            {
+                              "source": "answers",
+                              "identifier": "last-name"
+                            }
+                          ],
+                          " "
+                        ]
+                      }
+                    },
+                    "options": [
+                      {
+                        "label": "None of the above",
+                        "value": "None of the above"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "id": "dynamic-answer-options-group"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_dynamic_answer_options_no_static_options.json
+++ b/tests/schemas/valid/test_dynamic_answer_options_no_static_options.json
@@ -1,0 +1,182 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Dynamic answer options",
+  "theme": "default",
+  "description": "A questionnaire to demo dynamic answer options",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {
+      "summary": {
+        "collapsible": false
+      }
+    }
+  },
+  "sections": [
+    {
+      "id": "default-section",
+      "groups": [
+        {
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "mandatory-checkbox",
+              "question": {
+                "id": "mandatory-checkbox-question",
+                "title": "What extra toppings would you like?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "mandatory-checkbox-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "None",
+                        "value": "None"
+                      },
+                      {
+                        "label": "Cheese",
+                        "value": "Cheese"
+                      },
+                      {
+                        "label": "Ham",
+                        "value": "Ham"
+                      },
+                      {
+                        "label": "Pineapple",
+                        "value": "Pineapple"
+                      },
+                      {
+                        "label": "Tuna",
+                        "value": "Tuna"
+                      },
+                      {
+                        "label": "Pepperoni",
+                        "value": "Pepperoni"
+                      },
+                      {
+                        "label": "Other",
+                        "value": "Other",
+                        "description": "Choose any other topping",
+                        "detail_answer": {
+                          "mandatory": false,
+                          "id": "other-answer-mandatory",
+                          "label": "Please specify other",
+                          "type": "TextField"
+                        }
+                      }
+                    ],
+                    "type": "Checkbox"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "checkbox-with-dynamic-options",
+              "question": {
+                "id": "checkbox-with-dynamic-options-question",
+                "title": "Which one is your favourite?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-checkbox-answer",
+                    "mandatory": true,
+                    "type": "Checkbox",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "answers",
+                        "identifier": "mandatory-checkbox-answer"
+                      },
+                      "transform": {
+                        "option-label-from-value": [
+                          "self",
+                          "mandatory-checkbox-answer"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "radio-with-dynamic-options",
+              "question": {
+                "id": "radio-with-dynamic-options-question",
+                "title": "Which one is your favourite?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-radio-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "answers",
+                        "identifier": "mandatory-checkbox-answer"
+                      },
+                      "transform": {
+                        "option-label-from-value": [
+                          "self",
+                          "mandatory-checkbox-answer"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "dropdown-with-dynamic-options",
+              "question": {
+                "id": "dropdown-with-dynamic-options-question",
+                "title": "Which one is your favourite?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "dynamic-dropdown-answer",
+                    "mandatory": true,
+                    "type": "Dropdown",
+                    "label": "Select an option",
+                    "dynamic_options": {
+                      "values": {
+                        "source": "answers",
+                        "identifier": "mandatory-checkbox-answer"
+                      },
+                      "transform": {
+                        "option-label-from-value": [
+                          "self",
+                          "mandatory-checkbox-answer"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "id": "dynamic-answer-options-group"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_dynamic_answer_options_no_static_options.json
+++ b/tests/schemas/valid/test_dynamic_answer_options_no_static_options.json
@@ -4,9 +4,9 @@
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",
-  "title": "Dynamic answer options",
+  "title": "Dynamic answer options driven by a Checkbox (No static options)",
   "theme": "default",
-  "description": "A questionnaire to demo dynamic answer options",
+  "description": "A questionnaire to demo dynamic answer options driven by a Checkbox with no extra static options",
   "metadata": [
     {
       "name": "user_id",

--- a/tests/validators/answers/test_option_answer_validator.py
+++ b/tests/validators/answers/test_option_answer_validator.py
@@ -1,4 +1,5 @@
 from app.validators.answers import OptionAnswerValidator
+from tests.conftest import get_mock_schema
 
 
 def test_invalid_mismatching_answer_label_and_value():
@@ -124,3 +125,29 @@ def test_min_answer_options_with_dynamic_options():
     assert validator.errors == [
         {"message": validator.OPTIONS_DEFINED_BUT_EMPTY, "answer_id": "answer"}
     ]
+
+
+def test_dynamic_options_transform_allows_non_map_self_reference():
+    answer = {
+        "id": "answer",
+        "label": "Label",
+        "type": "Checkbox",
+        "dynamic_options": {
+            "values": {"source": "answers", "identifier": "checkbox-answer"},
+            "transform": {"option-label-from-value": ["self", "checkbox-answer"]},
+        },
+    }
+
+    validator = OptionAnswerValidator(
+        answer,
+        questionnaire_schema=get_mock_schema(
+            answers_with_context={
+                "checkbox-answer": {
+                    "answer": {"id": "checkbox-answer", "type": "Checkbox"}
+                }
+            }
+        ),
+    )
+    validator.validate_dynamic_options()
+
+    assert not validator.errors

--- a/tests/validators/answers/test_option_answer_validator.py
+++ b/tests/validators/answers/test_option_answer_validator.py
@@ -89,3 +89,38 @@ def test_validate_default_exists_in_options():
     validator.validate_default_exists_in_options()
 
     assert expected_errors == validator.errors
+
+
+def test_min_answer_options_without_dynamic_options():
+    answer_type = "Checkbox"
+    answer = {"id": "answer", "label": "Label", "type": answer_type, "options": []}
+
+    validator = OptionAnswerValidator(answer)
+    validator.validate_min_options()
+
+    assert validator.errors == [
+        {
+            "message": validator.INVALID_NUMBER_OF_ANSWER_OPTIONS.format(
+                answer_type=answer_type, required_num_options=1, actual_num_options=0
+            ),
+            "answer_id": "answer",
+        }
+    ]
+
+
+def test_min_answer_options_with_dynamic_options():
+    answer_type = "Checkbox"
+    answer = {
+        "id": "answer",
+        "label": "Label",
+        "type": answer_type,
+        "options": [],
+        "dynamic_options": {"values": {}, "transform": {}},
+    }
+
+    validator = OptionAnswerValidator(answer)
+    validator.validate_min_options()
+
+    assert validator.errors == [
+        {"message": validator.OPTIONS_DEFINED_BUT_EMPTY, "answer_id": "answer"}
+    ]

--- a/tests/validators/rules/test_rules_validator.py
+++ b/tests/validators/rules/test_rules_validator.py
@@ -2,6 +2,7 @@ import pytest
 
 from app.validators.questionnaire_schema import QuestionnaireSchema
 from app.validators.rules.rule_validator import RulesValidator
+from app.validators.value_source_validator import ValueSourceValidator
 from tests.conftest import get_mock_schema
 
 ORIGIN_ID = "block-id"
@@ -11,9 +12,18 @@ default_answer_with_context = {
 }
 
 
-def get_validator(rule, *, questionnaire_schema=None, answers_with_context=None):
+def get_validator(
+    rule,
+    *,
+    questionnaire_schema=None,
+    answers_with_context=None,
+    allow_self_reference=False,
+):
     return RulesValidator(
-        rule, ORIGIN_ID, get_mock_schema(questionnaire_schema, answers_with_context)
+        rule,
+        ORIGIN_ID,
+        get_mock_schema(questionnaire_schema, answers_with_context),
+        allow_self_reference=allow_self_reference,
     )
 
 
@@ -216,7 +226,9 @@ def test_map_operator_without_self_reference():
         ("format-date", [{"date": ["self"]}]),
     ],
 )
-def test_self_reference_outside_map_operator(operator_name, operands):
+def test_self_reference_outside_map_operator_without_allow_self_reference(
+    operator_name, operands
+):
     rule = {operator_name: operands}
 
     validator = get_validator(
@@ -224,6 +236,7 @@ def test_self_reference_outside_map_operator(operator_name, operands):
         answers_with_context={
             "date-answer": {"answer": {"id": "date-answer", "type": "Date"}}
         },
+        allow_self_reference=False,
     )
     validator.validate()
 
@@ -234,3 +247,37 @@ def test_self_reference_outside_map_operator(operator_name, operands):
     }
 
     assert expected_error in validator.errors
+
+
+@pytest.mark.parametrize(
+    "operator_name, operands",
+    [
+        ("date", ["self"]),
+        ("format-date", ["self"]),
+        ("format-date", [{"date": ["self"]}]),
+    ],
+)
+def test_self_reference_outside_map_operator_with_allow_self_reference(
+    operator_name, operands
+):
+    rule = {operator_name: operands}
+
+    validator = get_validator(rule, answers_with_context={}, allow_self_reference=True)
+    validator.validate()
+
+    assert not validator.errors
+
+
+def test_non_existing_answer_id_in_option_label_for_value_operator():
+    rule = {"option-label-from-value": ["self", "non-existing-answer"]}
+
+    validator = get_validator(rule, answers_with_context={}, allow_self_reference=True)
+    validator.validate()
+
+    expected_error = {
+        "message": ValueSourceValidator.ANSWER_REFERENCE_INVALID,
+        "origin_id": ORIGIN_ID,
+        "identifier": "non-existing-answer",
+    }
+
+    assert validator.errors == [expected_error]


### PR DESCRIPTION
### PR Context
- Added remaining implementations defined in [master/doc/decisions/0010-dynamic-answer-options.md](https://github.com/ONSdigital/eq-questionnaire-validator/blob/master/doc/decisions/0010-dynamic-answer-options.md) that wasn't implemented in https://github.com/ONSdigital/eq-questionnaire-validator/pull/125.
- Added support for `dynamic_options` for answers that support `options`.
	- Supports checkbox driven, list collector driven and function driven (date).
- Added the `concat` and `option-label-from-value` operators.
- Answer options length validation is now done in code as `options` are not mandatory when `dynamic_options` are defined.

Note: No validation has been added to ensure that some routing/skip rules exists somewhere in the schema to prevent cases where dynamic options is empty/invalid. The overhead in this is too great. Have confirmed this with Donna.

Ensure the changes are appropriate and no required validation has been missed.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
