### PR TITLE
Fix bug with options validator

### DIFF
--- a/app/validators/rules/rule_validator.py
+++ b/app/validators/rules/rule_validator.py
@@ -228,7 +228,7 @@ class RulesValidator(Validator):
 
         if values and option_values:
             for value in values:
-                # Null values are allowed and will not existing in answer options
+                # Null values are allowed and will not exist in answer options
                 if value and value not in option_values:
                     self.add_error(
                         self.VALUE_DOESNT_EXIST_IN_ANSWER_OPTIONS,

--- a/app/validators/rules/rule_validator.py
+++ b/app/validators/rules/rule_validator.py
@@ -228,9 +228,10 @@ class RulesValidator(Validator):
 
         if values and option_values:
             for value in values:
-                if value not in option_values:
+                # Null values are allowed and will not existing in answer options
+                if value and value not in option_values:
                     self.add_error(
                         self.VALUE_DOESNT_EXIST_IN_ANSWER_OPTIONS,
                         value=value,
-                        answer_options=option_values,
+                        answer_options=list(option_values),
                     )

--- a/tests/validators/rules/test_rules_validator.py
+++ b/tests/validators/rules/test_rules_validator.py
@@ -57,6 +57,36 @@ def test_validate_options(operator_name, first_argument, second_argument):
     assert validator.errors == [expected_error]
 
 
+@pytest.mark.parametrize(
+    "operator_name, first_argument, second_argument",
+    [
+        ("==", {"source": "answers", "identifier": "string-answer"}, None),
+        ("!=", {"source": "answers", "identifier": "string-answer"}, None),
+        ("in", {"source": "answers", "identifier": "string-answer"}, [None]),
+        ("any-in", {"source": "answers", "identifier": "array-answer"}, [None]),
+        ("all-in", [None], {"source": "answers", "identifier": "array-answer"}),
+    ],
+)
+def test_validate_options_null_value_is_valid(
+    operator_name, first_argument, second_argument
+):
+    rule = {operator_name: [first_argument, second_argument]}
+
+    questionnaire_schema = QuestionnaireSchema({})
+    questionnaire_schema.answers_with_context = {
+        "string-answer": {"answer": {"id": "string-answer", "type": "Radio"}},
+        "array-answer": {"answer": {"id": "array-answer", "type": "Checkbox"}},
+    }
+    questionnaire_schema.answer_id_to_option_values_map = {
+        "string-answer": ["Yes", "No"],
+        "array-answer": ["Yes", "No"],
+    }
+    validator = get_validator(rule, questionnaire_schema=questionnaire_schema)
+    validator.validate()
+
+    assert not validator.errors
+
+
 def test_validate_options_multiple_errors():
     rule = {
         "in": [


### PR DESCRIPTION
### PR Context
Small PR to fix a bug in options validator where it was expecting null values to be a valid answer option. Previously passed due to a bug with `answer_id_to_option_values_map` which didn't return the right answer options, but the last merge fixed that. Tests explicitly set `answer_id_to_option_values_map` hence that didn't pick it up. However, we explicitly set property in test when we shouldn't, so that will need revisiting as this is a classic example of why properties should be overridden. We also need to revisit the use of `cached_property` when using generators, as they do not go well together, as a generator can only be consumed once.

Run the validator against runner schemas and ensure they all pass validation.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
