### PR TITLE
Fix issue with questions-with-context finding all questions keys

### DIFF
--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -165,6 +165,7 @@ class QuestionnaireSchema:
         return [
             (match.value, get_context_from_match(match))
             for match in parse("$..question").find(self.schema)
+            if isinstance(match.value, dict)
         ]
 
     @property

--- a/tests/schemas/valid/test_introduction_with_questions.json
+++ b/tests/schemas/valid/test_introduction_with_questions.json
@@ -1,0 +1,66 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "theme": "default",
+  "title": "Test introduction with questions in preview content",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {}
+  },
+  "sections": [
+    {
+      "id": "introduction-section",
+      "title": "Introduction",
+      "groups": [
+        {
+          "id": "introduction-group",
+          "title": "Introduction",
+          "blocks": [
+            {
+              "id": "introduction",
+              "type": "Introduction",
+              "primary_content": [
+                {
+                  "id": "primary-content",
+                  "title": "Primary Content"
+                }
+              ],
+              "preview_content": {
+                "id": "preview-content",
+                "title": "Preview Content",
+                "questions": [
+                  {
+                    "id": "preview",
+                    "question": "Question",
+                    "contents": [
+                      {
+                        "description": "Question description"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_introduction_with_questions.json
+++ b/tests/schemas/valid/test_introduction_with_questions.json
@@ -5,7 +5,8 @@
   "data_version": "0.0.3",
   "survey_id": "0",
   "theme": "default",
-  "title": "Test introduction with questions in preview content",
+  "title": "Test introduction with question in preview content",
+  "description": "This questionnaire needs to exercise questions with context, so an answer placeholder has been added",
   "metadata": [
     {
       "name": "user_id",
@@ -47,13 +48,90 @@
                 "title": "Preview Content",
                 "questions": [
                   {
-                    "id": "preview",
-                    "question": "Question",
+                    "id": "name-question-preview",
+                    "question": "Name",
                     "contents": [
                       {
-                        "description": "Question description"
+                        "description": "Your name"
                       }
                     ]
+                  },
+                  {
+                    "id": "age-question-preview",
+                    "question": "Age",
+                    "contents": [
+                      {
+                        "description": "Your age"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "name-section",
+      "title": "Name Input",
+      "groups": [
+        {
+          "id": "name-group",
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "name",
+              "question": {
+                "id": "primary-name-question",
+                "title": "Please enter a name",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "name-answer",
+                    "label": "Name",
+                    "mandatory": true,
+                    "type": "TextField"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "age-input-section",
+      "title": "Age Input",
+      "groups": [
+        {
+          "id": "dob-input-group",
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "dob-question-block",
+              "question": {
+                "id": "dob-question",
+                "title": {
+                  "text": "What is {person_name} date of birth?",
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name",
+                      "value": {
+                        "identifier": "name-answer",
+                        "source": "answers"
+                      }
+                    }
+                  ]
+                },
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "date-of-birth-answer",
+                    "description": "Enter your date of birth",
+                    "label": "Date of Birth",
+                    "mandatory": true,
+                    "type": "Date"
                   }
                 ]
               }


### PR DESCRIPTION
### PR Context
At present def questions_with_context is returning all elements in the schema with the key "question", assuming each has a child element "answers" in. However the key "question" can also be used in a content block, at which point it will have no child "answers" and be a str instead throwing a 500. This PR makes sure question is a dict

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
