### PR TITLE
Clean tag variable in github pull request action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Tag
         run: |
           CLEAN_TAG=$(echo "${{ github.event.pull_request.head.ref  }}"  | tr / -)
-          echo "::set-env name=TAG::$CLEAN_TAG" > $GITHUB_ENV
+          echo "TAG=$CLEAN_TAG" >> $GITHUB_ENV
       - name: Build
         run: |
           docker build -t onsdigital/eq-questionnaire-validator:$TAG .

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,7 +74,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Tag
-        run: echo "TAG=${{ github.event.pull_request.head.ref }}" > $GITHUB_ENV
+        run: |
+          CLEAN_TAG=$(echo "${{ github.event.pull_request.head.ref  }}"  | tr / -)
+          echo "::set-env name=TAG::$CLEAN_TAG" > $GITHUB_ENV
       - name: Build
         run: |
           docker build -t onsdigital/eq-questionnaire-validator:$TAG .


### PR DESCRIPTION
### PR Context
When dependabot raises PRs it is creating branches with `/` in them. This causes errors with the docker build command when it is using the `-t --tag` flag.
![image](https://user-images.githubusercontent.com/42928680/151185747-ca6686b8-da07-4a0a-9c25-88e5065a6bb3.png)

Replacing these with `-` fixes this issue and will allow dependabot PRs to be tagged and merged correctly.

### How to review 
Check actions pr template correctly tags the docker image

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
