### PR TITLE
Add fix to calculations value source validation

### DIFF
--- a/app/validators/questions/calculated_question_validator.py
+++ b/app/validators/questions/calculated_question_validator.py
@@ -44,7 +44,7 @@ class CalculatedQuestionValidator(QuestionValidator):
             if answer_id := calculation.get("answer_id"):
                 self._validate_answer_is_numeric(answer_id)
 
-            elif value and value.get("source"):
+            elif isinstance(value, dict) and value.get("source"):
                 answer_id = value.get("identifier")
                 # Calculated summary value source is validated elsewhere and must be of a number type
 

--- a/tests/schemas/valid/test_calculations_value_source.json
+++ b/tests/schemas/valid/test_calculations_value_source.json
@@ -71,10 +71,7 @@
                   {
                     "calculation_type": "sum",
                     "value": 100,
-                    "answers_to_calculate": [
-                      "breakdown-1",
-                      "breakdown-2"
-                    ],
+                    "answers_to_calculate": ["breakdown-1", "breakdown-2"],
                     "conditions": ["equals"]
                   }
                 ],

--- a/tests/schemas/valid/test_calculations_value_source.json
+++ b/tests/schemas/valid/test_calculations_value_source.json
@@ -1,0 +1,104 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Calculated question with value sources test survey",
+  "theme": "default",
+  "description": "A survey that tests calculation is not checked for answer value source being one of Number types when calculations value is not a dict",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {
+      "summary": {
+        "collapsible": false
+      }
+    }
+  },
+  "sections": [
+    {
+      "id": "default-section",
+      "groups": [
+        {
+          "id": "group",
+          "title": "Validate sum against answer, calculated summary source",
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "total-block",
+              "question": {
+                "id": "total-question",
+                "title": "Total",
+                "description": [
+                  "Enter a number to breakdown in subsequent questions and calculated summary."
+                ],
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "total-answer",
+                    "label": "Total",
+                    "mandatory": true,
+                    "type": "TextField"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Question",
+              "id": "breakdown-block",
+              "question": {
+                "id": "breakdown-question",
+                "title": "Breakdown validated against an answer value source",
+                "description": [
+                  "This is a breakdown of the total number from the previous question."
+                ],
+                "type": "Calculated",
+                "calculations": [
+                  {
+                    "calculation_type": "sum",
+                    "value": 100,
+                    "answers_to_calculate": [
+                      "breakdown-1",
+                      "breakdown-2"
+                    ],
+                    "conditions": ["equals"]
+                  }
+                ],
+                "answers": [
+                  {
+                    "id": "breakdown-1",
+                    "label": "Breakdown 1",
+                    "mandatory": false,
+                    "decimal_places": 2,
+                    "type": "Number"
+                  },
+                  {
+                    "id": "breakdown-2",
+                    "label": "Breakdown 2",
+                    "mandatory": false,
+                    "decimal_places": 2,
+                    "type": "Number"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_calculations_value_source.json
+++ b/tests/schemas/valid/test_calculations_value_source.json
@@ -6,7 +6,7 @@
   "survey_id": "0",
   "title": "Calculated question with a number value source test survey",
   "theme": "default",
-  "description": "A survey that tests calculation is not checked for answer value source being one of Number types when calculations value is not a dict",
+  "description": "A survey that tests validation against a calculated question with a valid number value",
   "metadata": [
     {
       "name": "user_id",

--- a/tests/schemas/valid/test_calculations_value_source.json
+++ b/tests/schemas/valid/test_calculations_value_source.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",
-  "title": "Calculated question with value sources test survey",
+  "title": "Calculated question with a number value source test survey",
   "theme": "default",
   "description": "A survey that tests calculation is not checked for answer value source being one of Number types when calculations value is not a dict",
   "metadata": [
@@ -35,36 +35,16 @@
       "groups": [
         {
           "id": "group",
-          "title": "Validate sum against answer, calculated summary source",
+          "title": "Validate sum against value, calculated summary source",
           "blocks": [
-            {
-              "type": "Question",
-              "id": "total-block",
-              "question": {
-                "id": "total-question",
-                "title": "Total",
-                "description": [
-                  "Enter a number to breakdown in subsequent questions and calculated summary."
-                ],
-                "type": "General",
-                "answers": [
-                  {
-                    "id": "total-answer",
-                    "label": "Total",
-                    "mandatory": true,
-                    "type": "TextField"
-                  }
-                ]
-              }
-            },
             {
               "type": "Question",
               "id": "breakdown-block",
               "question": {
                 "id": "breakdown-question",
-                "title": "Breakdown validated against an answer value source",
+                "title": "Breakdown validated against a number value",
                 "description": [
-                  "This is a breakdown of the total number from the previous question."
+                  "This is a breakdown of the total from a number value."
                 ],
                 "type": "Calculated",
                 "calculations": [

--- a/tests/schemas/valid/test_calculations_with_numeric_value.json
+++ b/tests/schemas/valid/test_calculations_with_numeric_value.json
@@ -4,7 +4,7 @@
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",
-  "title": "Calculated question with a number value source test survey",
+  "title": "Calculated question with a number value test survey",
   "theme": "default",
   "description": "A survey that tests validation against a calculated question with a valid number value",
   "metadata": [


### PR DESCRIPTION
### PR Context
Currently our calculations value source validation breaks when value for calculation is not a dict type, this fixes the issue. Valid schema added with previously breaking `value` for calculations.

### Checklist

* [ ] eq-translations updated to support any new schema keys which need translation
