### PR TITLE
Validate theme in JSON schema

### DIFF
--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -46,7 +46,8 @@
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
     },
     "theme": {
-      "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
+      "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
+      "enum":["BUSINESS","SOCIAL","DEFAULT","HEALTH","NORTHEN_IRELAND","CENSUS","CENSUS_NISRA"]
     },
     "legal_basis": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -46,7 +46,6 @@
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"
     },
     "theme": {
-      "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
       "enum": [
         "business",
         "social",

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -47,7 +47,15 @@
     },
     "theme": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-      "enum": ["business","social","default","health","northernireland","census","census-nisra"]
+      "enum": [
+        "business",
+        "social",
+        "default",
+        "health",
+        "northernireland",
+        "census",
+        "census-nisra"
+      ]
     },
     "legal_basis": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/schemas/questionnaire_v1.json
+++ b/schemas/questionnaire_v1.json
@@ -47,7 +47,7 @@
     },
     "theme": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string",
-      "enum":["BUSINESS","SOCIAL","DEFAULT","HEALTH","NORTHEN_IRELAND","CENSUS","CENSUS_NISRA"]
+      "enum": ["business","social","default","health","northernireland","census","census-nisra"]
     },
     "legal_basis": {
       "$ref": "https://eq.ons.gov.uk/common_definitions.json#/non_empty_string"

--- a/tests/schemas/invalid/test_invalid_theme.json
+++ b/tests/schemas/invalid/test_invalid_theme.json
@@ -1,0 +1,86 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "data_version": "0.0.3",
+    "survey_id": "144",
+    "theme": "invalid theme",
+    "title": "Test Invalid Theme",
+    "legal_basis": "Notice is given under section 999 of the Test Act 2000",
+    "metadata": [
+      {
+        "name": "user_id",
+        "type": "string"
+      },
+      {
+        "name": "period_id",
+        "type": "string"
+      },
+      {
+        "name": "ru_name",
+        "type": "string"
+      },
+      {
+        "name": "ru_ref",
+        "type": "string"
+      },
+      {
+        "name": "trad_as",
+        "type": "string",
+        "optional": true
+      }
+    ],
+    "questionnaire_flow": {
+      "type": "Linear",
+      "options": {}
+    },
+    "sections": [
+      {
+        "id": "introduction-section",
+        "title": "Introduction",
+        "groups": [
+          {
+            "id": "introduction-group",
+            "title": "General Business Information",
+            "blocks": [
+              {
+                "id": "introduction",
+                "type": "Introduction",
+                "primary_content": [
+                  {
+                    "id": "business-details",
+                    "title": "You are completing this for ESSENTIAL ENTERPRISE LTD.",
+                    "contents": [
+                      {
+                        "guidance": {
+                          "contents": [
+                            {
+                              "title": "Coronavirus (COVID-19) guidance",
+                              "description": "<strong>Explain your figures</strong> in the comment section to minimise us contacting you and to help us tell an industry story"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "Interstitial",
+                "id": "general-business-information-completed",
+                "content": {
+                  "title": "Section complete",
+                  "contents": [
+                    {
+                      "description": "<p>You have successfully completed this section</p>"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/tests/schemas/invalid/test_invalid_theme.json
+++ b/tests/schemas/invalid/test_invalid_theme.json
@@ -1,86 +1,85 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "language": "en",
-    "schema_version": "0.0.1",
-    "data_version": "0.0.3",
-    "survey_id": "144",
-    "theme": "invalid theme",
-    "title": "Test Invalid Theme",
-    "legal_basis": "Notice is given under section 999 of the Test Act 2000",
-    "metadata": [
-      {
-        "name": "user_id",
-        "type": "string"
-      },
-      {
-        "name": "period_id",
-        "type": "string"
-      },
-      {
-        "name": "ru_name",
-        "type": "string"
-      },
-      {
-        "name": "ru_ref",
-        "type": "string"
-      },
-      {
-        "name": "trad_as",
-        "type": "string",
-        "optional": true
-      }
-    ],
-    "questionnaire_flow": {
-      "type": "Linear",
-      "options": {}
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "144",
+  "theme": "invalid theme",
+  "title": "Test Invalid Theme",
+  "legal_basis": "Notice is given under section 999 of the Test Act 2000",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
     },
-    "sections": [
-      {
-        "id": "introduction-section",
-        "title": "Introduction",
-        "groups": [
-          {
-            "id": "introduction-group",
-            "title": "General Business Information",
-            "blocks": [
-              {
-                "id": "introduction",
-                "type": "Introduction",
-                "primary_content": [
-                  {
-                    "id": "business-details",
-                    "title": "You are completing this for ESSENTIAL ENTERPRISE LTD.",
-                    "contents": [
-                      {
-                        "guidance": {
-                          "contents": [
-                            {
-                              "title": "Coronavirus (COVID-19) guidance",
-                              "description": "<strong>Explain your figures</strong> in the comment section to minimise us contacting you and to help us tell an industry story"
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "Interstitial",
-                "id": "general-business-information-completed",
-                "content": {
-                  "title": "Section complete",
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    },
+    {
+      "name": "ru_ref",
+      "type": "string"
+    },
+    {
+      "name": "trad_as",
+      "type": "string",
+      "optional": true
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {}
+  },
+  "sections": [
+    {
+      "id": "introduction-section",
+      "title": "Introduction",
+      "groups": [
+        {
+          "id": "introduction-group",
+          "title": "General Business Information",
+          "blocks": [
+            {
+              "id": "introduction",
+              "type": "Introduction",
+              "primary_content": [
+                {
+                  "id": "business-details",
+                  "title": "You are completing this for ESSENTIAL ENTERPRISE LTD.",
                   "contents": [
                     {
-                      "description": "<p>You have successfully completed this section</p>"
+                      "guidance": {
+                        "contents": [
+                          {
+                            "title": "Coronavirus (COVID-19) guidance",
+                            "description": "<strong>Explain your figures</strong> in the comment section to minimise us contacting you and to help us tell an industry story"
+                          }
+                        ]
+                      }
                     }
                   ]
                 }
+              ]
+            },
+            {
+              "type": "Interstitial",
+              "id": "general-business-information-completed",
+              "content": {
+                "title": "Section complete",
+                "contents": [
+                  {
+                    "description": "<p>You have successfully completed this section</p>"
+                  }
+                ]
               }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### PR Context
The theme property in schemas can be set to any string which can cause the survey fail to launch. This PR validates that the theme used is the ones supported by the eQ Runner.

### Checklist
-  Passes `make validate-test-schemas ` in eQ Runner
- * [ ] eq-translations updated to support any new schema keys which need translation
