### PR TITLE
Re-enable q_codes validation

### DIFF
--- a/app/validators/answers/answer_validator.py
+++ b/app/validators/answers/answer_validator.py
@@ -29,8 +29,7 @@ class AnswerValidator(Validator):
         self.questionnaire_schema = questionnaire_schema
 
     def validate(self):
-        # :TODO: Re-introduce once business teams are ready!
-        # self._validate_q_codes()
+        self._validate_q_codes()
 
         return self.errors
 

--- a/tests/validators/answers/test_answer_validator.py
+++ b/tests/validators/answers/test_answer_validator.py
@@ -1,5 +1,3 @@
-import pytest
-
 from app.validators.answers import get_answer_validator
 from app.validators.answers.answer_validator import AnswerValidator
 from app.validators.answers.date_answer_validator import DateAnswerValidator
@@ -50,7 +48,6 @@ def test_invalid_single_date_period():
     assert not answer_validator.is_offset_date_valid()
 
 
-@pytest.mark.skip(reason="Q Code validation is currently disabled!")
 def test_confirmation_question_q_code():
     filename = "schemas/valid/test_q_codes.json"
     schema = QuestionnaireSchema(_open_and_load_schema_file(filename))
@@ -70,7 +67,6 @@ def test_confirmation_question_q_code():
     assert expected_error_messages == validator.errors
 
 
-@pytest.mark.skip(reason="Q Code validation is currently disabled!")
 def test_data_version_0_0_3_q_code():
     # valid schema for test purposes, q_code is injected
     filename = "schemas/valid/test_interstitial_instruction.json"
@@ -91,7 +87,6 @@ def test_data_version_0_0_3_q_code():
     assert expected_error_messages == validator.errors
 
 
-@pytest.mark.skip(reason="Q Code validation is currently disabled!")
 def test_invalid_q_codes():
     filename = "schemas/invalid/test_invalid_q_code.json"
     json_to_validate = _open_and_load_schema_file(filename)


### PR DESCRIPTION
### PR Context
We can re-enable our existing validation since `q_codes` gaps in every business schema will be fixed soon.

### Checklist
3 unit tests are checking if test schema is validated correctly.

* [ ] eq-translations updated to support any new schema keys which need translation
