### PR TITLE
Bug: Fix for answer code validation when using list collectors

### DIFF
--- a/app/validators/answer_code_validator.py
+++ b/app/validators/answer_code_validator.py
@@ -81,7 +81,7 @@ class AnswerCodeValidator(Validator):
                     self.add_error(
                         self.INVALID_ANSWER_CODE_FOR_LIST_COLLECTOR, answer_id=answer_id
                     )
-                break
+                continue
 
             if answer_id not in self.answer_codes_answer_ids:
                 self.add_error(self.MISSING_ANSWER_CODE, answer_id=answer_id)
@@ -114,7 +114,7 @@ class AnswerCodeValidator(Validator):
             block = self.questionnaire_schema.get_block_by_answer_id(answer_id)
 
             if block["type"] in ["ListEditQuestion", "ListRemoveQuestion"]:
-                break
+                continue
 
             if "options" in answer["answer"]:
                 values = []

--- a/tests/schemas/valid/test_answer_codes_list_collector.json
+++ b/tests/schemas/valid/test_answer_codes_list_collector.json
@@ -53,6 +53,14 @@
     {
       "answer_id": "householder-checkbox-answer",
       "code": "5"
+    },
+    {
+      "answer_id": "first-name",
+      "code": "6"
+    },
+    {
+      "answer_id": "last-name",
+      "code": "7"
     }
   ],
   "questionnaire_flow": {

--- a/tests/test_answer_code_validator.py
+++ b/tests/test_answer_code_validator.py
@@ -716,7 +716,15 @@ def test_missing_answer_codes_for_list_add_questions():
         {
             "message": validator.MISSING_ANSWER_CODE,
             "answer_id": "registration-number",
-        }
+        },
+        {
+            "message": validator.MISSING_ANSWER_CODE,
+            "answer_id": "first-name",
+        },
+        {
+            "message": validator.MISSING_ANSWER_CODE,
+            "answer_id": "last-name",
+        },
     ]
 
     assert validator.errors == expected_errors
@@ -747,7 +755,15 @@ def test_invalid_answer_codes_for_list_collector_remove_question():
         {
             "message": validator.INVALID_ANSWER_CODE_FOR_LIST_COLLECTOR,
             "answer_id": "remove-confirmation",
-        }
+        },
+        {
+            "message": validator.MISSING_ANSWER_CODE,
+            "answer_id": "first-name",
+        },
+        {
+            "message": validator.MISSING_ANSWER_CODE,
+            "answer_id": "last-name",
+        },
     ]
 
     assert validator.errors == expected_errors


### PR DESCRIPTION
### What is the context of this PR?
> Update the break clause to use continue for the following:
>[eq-questionnaire-validator/answer_code_validator.py at master · ONSdigital/eq-questionnaire-validator](https://github.com/ONSdigital/eq-questionnaire-validator/blob/master/app/validators/answer_code_validator.py#L116-L117)
[eq-questionnaire-validator/answer_code_validator.py at master · ONSdigital/eq-questionnaire-validator](https://github.com/ONSdigital/eq-questionnaire-validator/blob/master/app/validators/answer_code_validator.py#L79-L84)
### How to review
> Modified the Unit test to include the errors and checked the valid ones
### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
