### PR TITLE
Update definition definitions

### DIFF
--- a/schemas/common_definitions.json
+++ b/schemas/common_definitions.json
@@ -76,19 +76,17 @@
   },
   "definition": {
     "description": "Definition title and contents.",
-    "items": {
-      "type": "object",
-      "required": ["title", "contents"],
-      "properties": {
-        "title": {
-          "$ref": "#/non_empty_string"
-        },
-        "contents": {
-          "$ref": "#/contents"
-        }
+    "type": "object",
+    "required": ["title", "contents"],
+    "properties": {
+      "title": {
+        "$ref": "#/non_empty_string"
       },
-      "additionalProperties": false
-    }
+      "contents": {
+        "$ref": "#/contents"
+      }
+    },
+    "additionalProperties": false
   },
   "skip_conditions": {
     "description": "Allows an element to be skipped when a condition has been met. By adding more than one `when` element it will evaluate as an or rule.",


### PR DESCRIPTION
### What is the context of this PR?
This updates the definitions to remove the items object which is causing the definitions to not be validated properly. Currently `test_question_definition` is passing validation when it should fail. This is because the definition is using "content" instead of "contents".

### How to review
- Test that using the Runner main branch and validator main branch passes validation
- Test that this branch along with the Runner main branch fails validation on `test_question_definition`
- Test that this branch along with the Runner `update-question-definition` branch where "content" is renamed to "contents" and is an array of objects (which is what it should be) in the `test_question_definition` it passes validation 

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
