### PR TITLE
Add test for validate_value_in_limits

### DIFF
--- a/tests/test_value_source_validator.py
+++ b/tests/test_value_source_validator.py
@@ -1,7 +1,9 @@
 import pytest
 
+from app.validators.answers.number_answer_validator import NumberAnswerValidator
 from app.validators.questionnaire_schema import QuestionnaireSchema
 from app.validators.value_source_validator import ValueSourceValidator
+from tests.conftest import get_mock_schema_with_data_version
 
 
 @pytest.mark.parametrize(
@@ -136,3 +138,65 @@ def test_invalid_composite_answer_field_in_selector():
     error = validator.errors[0]
     assert error["message"] == ValueSourceValidator.COMPOSITE_ANSWER_FIELD_INVALID
     assert error["identifier"] == "address-answer"
+
+
+def test_answer_source_refrences_value_source():
+    value_sources = [
+        {
+            "identifier": "set-minimum",
+            "source": "answers",
+        },
+        {
+            "identifier": "set-maximum",
+            "source": "answers",
+        },
+    ]
+
+    answer = {
+        "id": "min-max-range",
+        "mandatory": False,
+        "minimum": {"value": {"identifier": "set-minimum", "source": "answers"}},
+        "maximum": {"value": {"identifier": "set-maximum", "source": "answers"}},
+        "type": "Number",
+    }
+
+    answers = {"answers": [answer]}
+    questionnaire_schema = QuestionnaireSchema(answers)
+
+    questionnaire_schema.answers_with_context = {
+        "set-maximum": {"answer": {"id": "set-maximum", "type": "Number"}},
+        "set-minimum": {"answer": {"id": "set-minimum", "type": "Number"}},
+        "min-max-range": {
+            "answer": {
+                "id": "min-max-range",
+                "type": "Number",
+                "minimum": {
+                    "value": {"identifier": "set-minimum", "source": "answers"}
+                },
+                "maximum": {
+                    "value": {"identifier": "set-maximum", "source": "answers"}
+                },
+            }
+        },
+    }
+
+    for value_source in value_sources:
+        value_source_validator = ValueSourceValidator(
+            value_source, "", questionnaire_schema
+        )
+        value_source_validator.validate()
+
+    number_answer_validator = NumberAnswerValidator(
+        answer, get_mock_schema_with_data_version("0.0.3")
+    )
+    number_answer_validator.validate_referred_numeric_answer(
+        questionnaire_schema.numeric_answer_ranges
+    )
+
+    min_max_range = questionnaire_schema.get_answer("min-max-range")
+    min_max_minimum_value = min_max_range["minimum"]["value"]
+    min_max_maximum_value = min_max_range["maximum"]["value"]
+
+    assert min_max_minimum_value == value_sources[0]
+    assert min_max_maximum_value == value_sources[1]
+

--- a/tests/validators/answers/test_number_answer_validator.py
+++ b/tests/validators/answers/test_number_answer_validator.py
@@ -211,14 +211,14 @@ def test_invalid_maximum_minimum_value_from_answer_source():
     expected_errors = [
         {
             "message": validator.MINIMUM_LESS_THAN_LIMIT,
-            "value": -9999999999999999,
-            "limit": -999999999999999,
+            "value": -9_999_999_999_999_999,
+            "limit": MIN_NUMBER,
             "answer_id": "min-max-range",
         },
         {
             "message": validator.MAXIMUM_GREATER_THAN_LIMIT,
-            "value": 9999999999999999,
-            "limit": 999999999999999,
+            "value": 9_999_999_999_999_999,
+            "limit": MAX_NUMBER,
             "answer_id": "min-max-range",
         },
     ]

--- a/tests/validators/answers/test_number_answer_validator.py
+++ b/tests/validators/answers/test_number_answer_validator.py
@@ -209,5 +209,21 @@ def test_invalid_maximum_minimum_value_from_answer_source():
     validator.validate_value_in_limits()
 
     errors = validator.errors
-    assert errors[0]["message"] == validator.MINIMUM_LESS_THAN_LIMIT
-    assert errors[1]["message"] == validator.MAXIMUM_GREATER_THAN_LIMIT
+    print(errors)
+
+    expected_errors = [
+        {
+            "message": "Minimum value is less than system limit",
+            "value": -9999999999999999,
+            "limit": -999999999999999,
+            "answer_id": "min-max-range",
+        },
+        {
+            "message": "Maximum value is greater than system limit",
+            "value": 9999999999999999,
+            "limit": 999999999999999,
+            "answer_id": "min-max-range",
+        },
+    ]
+    
+    assert errors == expected_errors

--- a/tests/validators/answers/test_number_answer_validator.py
+++ b/tests/validators/answers/test_number_answer_validator.py
@@ -175,3 +175,39 @@ def test_invalid_numeric_answers():
     ]
 
     assert validator.errors == expected_errors
+
+
+def test_invalid_maximum_minimum_value_from_answer_source():
+    answer = {
+        "id": "min-max-range",
+        "mandatory": False,
+        "minimum": {"value": {"identifier": "set-minimum", "source": "answers"}},
+        "maximum": {"value": {"identifier": "set-maximum", "source": "answers"}},
+        "type": "Number",
+    }
+
+    answers = {
+        "answers": [
+            answer,
+            {
+                "id": "set-minimum",
+                "type": "Number",
+                "minimum": {"value": -999_999_999_999_999},
+            },
+            {
+                "id": "set-maximum",
+                "type": "Number",
+                "maximum": {"value": 9_999_999_999_999_999},
+            },
+        ]
+    }
+
+    questionnaire_schema = QuestionnaireSchema(answers)
+
+    validator = NumberAnswerValidator(answer, questionnaire_schema)
+
+    validator.validate_value_in_limits()
+
+    errors = validator.errors
+    assert errors[0]["message"] == validator.MINIMUM_LESS_THAN_LIMIT
+    assert errors[1]["message"] == validator.MAXIMUM_GREATER_THAN_LIMIT

--- a/tests/validators/answers/test_number_answer_validator.py
+++ b/tests/validators/answers/test_number_answer_validator.py
@@ -192,7 +192,7 @@ def test_invalid_maximum_minimum_value_from_answer_source():
             {
                 "id": "set-minimum",
                 "type": "Number",
-                "minimum": {"value": -999_999_999_999_999},
+                "minimum": {"value": -9_999_999_999_999_999},
             },
             {
                 "id": "set-maximum",

--- a/tests/validators/answers/test_number_answer_validator.py
+++ b/tests/validators/answers/test_number_answer_validator.py
@@ -209,7 +209,6 @@ def test_invalid_maximum_minimum_value_from_answer_source():
     validator.validate_value_in_limits()
 
     errors = validator.errors
-    print(errors)
 
     expected_errors = [
         {
@@ -225,5 +224,5 @@ def test_invalid_maximum_minimum_value_from_answer_source():
             "answer_id": "min-max-range",
         },
     ]
-    
+
     assert errors == expected_errors

--- a/tests/validators/answers/test_number_answer_validator.py
+++ b/tests/validators/answers/test_number_answer_validator.py
@@ -206,9 +206,7 @@ def test_invalid_maximum_minimum_value_from_answer_source():
 
     validator = NumberAnswerValidator(answer, questionnaire_schema)
 
-    validator.validate_value_in_limits()
-
-    errors = validator.errors
+    errors = validator.validate_value_in_limits().errors
 
     expected_errors = [
         {

--- a/tests/validators/answers/test_number_answer_validator.py
+++ b/tests/validators/answers/test_number_answer_validator.py
@@ -212,13 +212,13 @@ def test_invalid_maximum_minimum_value_from_answer_source():
 
     expected_errors = [
         {
-            "message": "Minimum value is less than system limit",
+            "message": validator.MINIMUM_LESS_THAN_LIMIT,
             "value": -9999999999999999,
             "limit": -999999999999999,
             "answer_id": "min-max-range",
         },
         {
-            "message": "Maximum value is greater than system limit",
+            "message": validator.MAXIMUM_GREATER_THAN_LIMIT,
             "value": 9999999999999999,
             "limit": 999999999999999,
             "answer_id": "min-max-range",

--- a/tests/validators/answers/test_number_answer_validator.py
+++ b/tests/validators/answers/test_number_answer_validator.py
@@ -206,7 +206,7 @@ def test_invalid_maximum_minimum_value_from_answer_source():
 
     validator = NumberAnswerValidator(answer, questionnaire_schema)
 
-    errors = validator.validate_value_in_limits().errors
+    validator.validate_value_in_limits()
 
     expected_errors = [
         {
@@ -223,4 +223,4 @@ def test_invalid_maximum_minimum_value_from_answer_source():
         },
     ]
 
-    assert errors == expected_errors
+    assert validator.errors == expected_errors


### PR DESCRIPTION
## What is the context of this PR?
Add test for recent change to `validate_value_in_limits`. Pull request of the change referenced is [here.](https://github.com/ONSdigital/eq-questionnaire-validator/pull/191).  

Testing that when min and max is using an answer value source, the min range and max range comes from the derived answer. 

Initially was suggested to test in `ValueSourceValidator` , but didnt see the need. Let me know if i missed the reason why.

Trello card is [here](https://trello.com/c/0yJIjinU/5658-enable-up-to-15-digits-in-relevant-fields-1-sp)
### How to review
- Check if test covers all changes
- Do we need more tests?


### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
