### PR TITLE
Looping 4 - Allow calculated summary using single repeating answer

### DIFF
--- a/app/validators/blocks/calculated_summary_block_validator.py
+++ b/app/validators/blocks/calculated_summary_block_validator.py
@@ -6,7 +6,7 @@ class CalculatedSummaryBlockValidator(CalculationBlockValidator):
         "Answer ids for calculated summary must be set before calculated summary block"
     )
     ANSWER_SET_IN_DIFFERENT_SECTION_FOR_CALCULATED_SUMMARY = "Answer ids for calculated summary must be set in the same section as the calculated summary block"
-    CALCULATED_SUMMARY_WITH_NON_DYNAMIC_SINGLE_ANSWER = "Calculated summaries cannot consist of a single answer unless it is a dynamic answer"
+    CALCULATED_SUMMARY_WITH_NON_REPEATING_SINGLE_ANSWER = "Calculated summaries cannot consist of a single answer unless it is a repeating answer"
 
     def __init__(self, block, questionnaire_schema):
         super().__init__(block, questionnaire_schema)
@@ -32,25 +32,23 @@ class CalculatedSummaryBlockValidator(CalculationBlockValidator):
         """Validate that if there is only one answer in the answers_to_calculate list, it's for repeating answers"""
         if len(answers) == 1:
             single_answer_id = answers[0]["id"]
+            question_block = self.questionnaire_schema.get_block_by_answer_id(
+                single_answer_id
+            )
             # check if its dynamic
             if (
                 single_answer_id
                 in self.questionnaire_schema.get_all_dynamic_answer_ids(
-                    self.questionnaire_schema.get_block_id_by_answer_id(
-                        single_answer_id
-                    )
+                    question_block["id"]
                 )
             ):
                 return
             # check if it's for a repeating question
-            question_block = self.questionnaire_schema.get_block_by_answer_id(
-                single_answer_id
-            )
             if question_block["type"] == "ListRepeatingQuestion":
                 return
 
             self.add_error(
-                self.CALCULATED_SUMMARY_WITH_NON_DYNAMIC_SINGLE_ANSWER,
+                self.CALCULATED_SUMMARY_WITH_NON_REPEATING_SINGLE_ANSWER,
                 block_id=self.block["id"],
                 answer_id=single_answer_id,
             )

--- a/app/validators/blocks/calculated_summary_block_validator.py
+++ b/app/validators/blocks/calculated_summary_block_validator.py
@@ -20,7 +20,7 @@ class CalculatedSummaryBlockValidator(CalculationBlockValidator):
         if (answers := self.get_answers(self.answers_to_calculate)) is None:
             return self.errors
 
-        self.validate_single_answer_is_for_dynamic_answers(answers)
+        self.validate_single_answer_is_for_repeating_answers(answers)
         self.validate_answer_id_set_before_calculated_summary_block()
         self.validate_answer_id_for_calculated_summary_not_in_different_section()
 
@@ -28,23 +28,32 @@ class CalculatedSummaryBlockValidator(CalculationBlockValidator):
 
         return self.errors
 
-    def validate_single_answer_is_for_dynamic_answers(self, answers: list[dict]):
-        """Validate that if there is only one answer in the answers_to_calculate list, it's for dynamic answers"""
+    def validate_single_answer_is_for_repeating_answers(self, answers: list[dict]):
+        """Validate that if there is only one answer in the answers_to_calculate list, it's for repeating answers"""
         if len(answers) == 1:
             single_answer_id = answers[0]["id"]
+            # check if its dynamic
             if (
                 single_answer_id
-                not in self.questionnaire_schema.get_all_dynamic_answer_ids(
+                in self.questionnaire_schema.get_all_dynamic_answer_ids(
                     self.questionnaire_schema.get_block_id_by_answer_id(
                         single_answer_id
                     )
                 )
             ):
-                self.add_error(
-                    self.CALCULATED_SUMMARY_WITH_NON_DYNAMIC_SINGLE_ANSWER,
-                    block_id=self.block["id"],
-                    answer_id=single_answer_id,
-                )
+                return
+            # check if it's for a repeating question
+            question_block = self.questionnaire_schema.get_block_by_answer_id(
+                single_answer_id
+            )
+            if question_block["type"] == "ListRepeatingQuestion":
+                return
+
+            self.add_error(
+                self.CALCULATED_SUMMARY_WITH_NON_DYNAMIC_SINGLE_ANSWER,
+                block_id=self.block["id"],
+                answer_id=single_answer_id,
+            )
 
     def validate_answer_id_set_before_calculated_summary_block(self):
         for answer_id in self.answers_to_calculate:

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -111,9 +111,7 @@ class QuestionnaireSchema:
             *parse("$..repeating_blocks[*]").find(self.schema),
         ]
         # order the blocks by the order that they occur in the json schema
-        self.sorted_matches = sorted(
-            (match for match in self.matches), key=json_path_position
-        )
+        self.sorted_matches = sorted(self.matches, key=json_path_position)
         self.blocks = [match.value for match in self.sorted_matches]
         self.blocks_by_id = {block["id"]: block for block in self.blocks}
         self.block_ids = list(self.blocks_by_id.keys())

--- a/tests/schemas/valid/test_new_calculated_summary_repeating_blocks.json
+++ b/tests/schemas/valid/test_new_calculated_summary_repeating_blocks.json
@@ -1,0 +1,393 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Calculated Summary of answers from Repeating blocks",
+  "theme": "default",
+  "description": "A demo of a calculated summary which uses a answers from the repeating blocks in a list collector.",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Hub",
+    "options": { "required_completed_sections": ["section"] }
+  },
+  "sections": [
+    {
+      "id": "section",
+      "title": "Transport",
+      "summary": {
+        "show_on_completion": true,
+        "items": [
+          {
+            "type": "List",
+            "for_list": "transport",
+            "title": "transport",
+            "item_anchor_answer_id": "transport-name",
+            "item_label": "Name of transport",
+            "add_link_text": "Add another method of transport",
+            "empty_list_text": "No method of transport added"
+          }
+        ],
+        "show_non_item_answers": true
+      },
+      "groups": [
+        {
+          "id": "group",
+          "blocks": [
+            {
+              "id": "block-car",
+              "type": "Question",
+              "question": {
+                "id": "question-car",
+                "type": "General",
+                "title": "How much do you spend per month travelling by Car?",
+                "answers": [
+                  {
+                    "id": "answer-car",
+                    "label": "Monthly expenditure travelling by car",
+                    "mandatory": false,
+                    "type": "Currency",
+                    "currency": "GBP"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "for_list": "transport",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Do you use any other methods of transport?",
+                "answers": [
+                  {
+                    "id": "list-collector-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-transport",
+                "type": "ListAddQuestion",
+                "cancel_text": "Don’t need to add any other method of transport?",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What other method of transport do you use?",
+                  "answers": [
+                    {
+                      "id": "transport-name",
+                      "label": "Transport",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Tube",
+                          "value": "Tube"
+                        },
+                        {
+                          "label": "Bus",
+                          "value": "Bus"
+                        },
+                        {
+                          "label": "Train",
+                          "value": "Train"
+                        },
+                        {
+                          "label": "Plane",
+                          "value": "Plane"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-transport",
+                "type": "ListEditQuestion",
+                "cancel_text": "Don’t need to add any other method of transport?",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What other method of transport do you use?",
+                  "answers": [
+                    {
+                      "id": "transport-name",
+                      "label": "Transport",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Tube",
+                          "value": "Tube"
+                        },
+                        {
+                          "label": "Bus",
+                          "value": "Bus"
+                        },
+                        {
+                          "label": "Train",
+                          "value": "Train"
+                        },
+                        {
+                          "label": "Plane",
+                          "value": "Plane"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-transport",
+                "type": "ListRemoveQuestion",
+                "cancel_text": "Don’t need to remove this method of transport?",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this method of transport?",
+                  "warning": "All of the information about this method of transport will be deleted",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "repeating_blocks": [
+                {
+                  "id": "transport-repeating-block-1",
+                  "type": "ListRepeatingQuestion",
+                  "question": {
+                    "id": "transport-repeating-block-1-question",
+                    "type": "General",
+                    "title": {
+                      "text": "Give details of your expenditure travelling by {transport_name}",
+                      "placeholders": [
+                        {
+                          "placeholder": "transport_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "transport-name"
+                          }
+                        }
+                      ]
+                    },
+                    "answers": [
+                      {
+                        "id": "transport-company",
+                        "label": {
+                          "placeholders": [
+                            {
+                              "placeholder": "transport_name",
+                              "value": {
+                                "source": "answers",
+                                "identifier": "transport-name"
+                              }
+                            }
+                          ],
+                          "text": "Which company do primarily use for travelling by {transport_name}?"
+                        },
+                        "mandatory": true,
+                        "type": "TextField"
+                      },
+                      {
+                        "id": "transport-cost",
+                        "label": {
+                          "placeholders": [
+                            {
+                              "placeholder": "transport_name",
+                              "value": {
+                                "source": "answers",
+                                "identifier": "transport-name"
+                              }
+                            }
+                          ],
+                          "text": "Monthly season ticket expenditure for travel by {transport_name}"
+                        },
+                        "mandatory": true,
+                        "type": "Currency",
+                        "currency": "GBP"
+                      },
+                      {
+                        "id": "transport-additional-cost",
+                        "label": {
+                          "placeholders": [
+                            {
+                              "placeholder": "transport_name",
+                              "value": {
+                                "source": "answers",
+                                "identifier": "transport-name"
+                              }
+                            }
+                          ],
+                          "text": "Additional monthly expenditure for travel by {transport_name}"
+                        },
+                        "mandatory": true,
+                        "type": "Currency",
+                        "currency": "GBP"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "transport-repeating-block-2",
+                  "type": "ListRepeatingQuestion",
+                  "question": {
+                    "id": "transport-repeating-block-2-question-1",
+                    "type": "General",
+                    "title": {
+                      "text": "How often do you travel by {transport_name}?",
+                      "placeholders": [
+                        {
+                          "placeholder": "transport_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "transport-name"
+                          }
+                        }
+                      ]
+                    },
+                    "answers": [
+                      {
+                        "id": "transport-count",
+                        "label": {
+                          "placeholders": [
+                            {
+                              "placeholder": "transport_name",
+                              "value": {
+                                "source": "answers",
+                                "identifier": "transport-name"
+                              }
+                            }
+                          ],
+                          "text": "Monthly journeys by {transport_name}"
+                        },
+                        "mandatory": true,
+                        "type": "Number"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "summary": {
+                "title": "transport",
+                "item_title": {
+                  "text": "{transport_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "transport_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "transport-name"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "CalculatedSummary",
+              "id": "calculated-summary-spending",
+              "title": "We calculate the total monthly expenditure on transport to be %(total)s. Is this correct?",
+              "calculation": {
+                "title": "Monthly transport expenditure",
+                "operation": {
+                  "+": [
+                    {
+                      "source": "answers",
+                      "identifier": "answer-car"
+                    },
+                    {
+                      "source": "answers",
+                      "identifier": "transport-cost"
+                    },
+                    {
+                      "source": "answers",
+                      "identifier": "transport-additional-cost"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "CalculatedSummary",
+              "id": "calculated-summary-count",
+              "title": "We calculate the total journeys made per month to be %(total)s. Is this correct?",
+              "calculation": {
+                "title": "Monthly journeys",
+                "operation": {
+                  "+": [
+                    {
+                      "source": "answers",
+                      "identifier": "transport-count"
+                    }
+                  ]
+                }
+              },
+              "skip_conditions": {
+                "when": {
+                  "==": [
+                    {
+                      "count": [
+                        {
+                          "source": "list",
+                          "identifier": "transport"
+                        }
+                      ]
+                    },
+                    0
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/validators/blocks/test_calculated_summary_block_validator.py
+++ b/tests/validators/blocks/test_calculated_summary_block_validator.py
@@ -69,7 +69,7 @@ def test_invalid_new_calculated_summary():
             "block_id": "total-playback-answer-error",
         },
         {
-            "message": CalculatedSummaryBlockValidator.CALCULATED_SUMMARY_WITH_NON_DYNAMIC_SINGLE_ANSWER,
+            "message": CalculatedSummaryBlockValidator.CALCULATED_SUMMARY_WITH_NON_REPEATING_SINGLE_ANSWER,
             "block_id": "total-playback-not-enough-answers",
             "answer_id": "fourth-number-answer",
         },
@@ -169,7 +169,7 @@ def test_invalid_calculated_summary_with_single_static_answer():
         {
             "block_id": "invalid-calculated-summary-with-single-static-answer",
             "answer_id": "cost-of-season-ticket",
-            "message": CalculatedSummaryBlockValidator.CALCULATED_SUMMARY_WITH_NON_DYNAMIC_SINGLE_ANSWER,
+            "message": CalculatedSummaryBlockValidator.CALCULATED_SUMMARY_WITH_NON_REPEATING_SINGLE_ANSWER,
         }
     ]
 


### PR DESCRIPTION
### What is the context of this PR?
This PR updates existing validation to calculated summaries to allow a calculated summary using a single answer id from a repeating block

One of the existing checks is that any answer in a calculated summary comes before the calculated summary. This check was not working correctly because we were populating the questionnaire schemas block ids, first with standard blocks, then add/edit/remove and then repeating blocks, resulting in repeating blocks always coming after the calculated summary blocks

To fix this a method has been added that converts the json path of each block match, into a tuple of its position, and this is used to sort the blocks

The only other change needed was to update the existing check in `calculated_summary_block_validator` to allow the single answer id to correspond to dynamic _or_ repeating question answers.

[Corresponding runner PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/1157)

### How to review
Check that with the new changes to `questionnaire_schema` that the blocks are now showing in the correct order. Additionally confirm that this allows a calculated summary with a single repeating block answer id or dynamic answer id, but not a single standard answer. This shouldn't need any additional tests but comment if you think of one

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
