### PR TITLE
Add validation for grand calculated summaries referencing repeating calculated summaries

### DIFF
--- a/app/validators/blocks/block_validator.py
+++ b/app/validators/blocks/block_validator.py
@@ -1,4 +1,7 @@
-from app.validators.questionnaire_schema import get_object_containing_key
+from app.validators.questionnaire_schema import (
+    QuestionnaireSchema,
+    get_object_containing_key,
+)
 from app.validators.validator import Validator
 
 
@@ -10,7 +13,7 @@ class BlockValidator(Validator):
         "Placeholder references an answer in the same block (self-reference)"
     )
 
-    def __init__(self, block_element, questionnaire_schema):
+    def __init__(self, block_element, questionnaire_schema: QuestionnaireSchema):
         super().__init__(block_element)
         self.questionnaire_schema = questionnaire_schema
         self.block = block_element

--- a/app/validators/blocks/block_validator.py
+++ b/app/validators/blocks/block_validator.py
@@ -1,3 +1,5 @@
+from typing import Mapping
+
 from app.validators.questionnaire_schema import (
     QuestionnaireSchema,
     get_object_containing_key,
@@ -13,7 +15,9 @@ class BlockValidator(Validator):
         "Placeholder references an answer in the same block (self-reference)"
     )
 
-    def __init__(self, block_element, questionnaire_schema: QuestionnaireSchema):
+    def __init__(
+        self, block_element: Mapping, questionnaire_schema: QuestionnaireSchema
+    ):
         super().__init__(block_element)
         self.questionnaire_schema = questionnaire_schema
         self.block = block_element

--- a/app/validators/blocks/grand_calculated_summary_block_validator.py
+++ b/app/validators/blocks/grand_calculated_summary_block_validator.py
@@ -1,3 +1,5 @@
+from typing import Mapping
+
 from app.validators.blocks.calculation_block_validator import CalculationBlockValidator
 from app.validators.questionnaire_schema import (
     QuestionnaireSchema,
@@ -17,7 +19,7 @@ class GrandCalculatedSummaryBlockValidator(CalculationBlockValidator):
         " a repeating calculated summary in a different repeating section"
     )
 
-    def __init__(self, block, questionnaire_schema: QuestionnaireSchema):
+    def __init__(self, block: Mapping, questionnaire_schema: QuestionnaireSchema):
         super().__init__(block, questionnaire_schema)
         self.answers_to_calculate: list[str] = []
         # check calculated summary answers sets to verify no two calculated summaries are identical

--- a/app/validators/blocks/grand_calculated_summary_block_validator.py
+++ b/app/validators/blocks/grand_calculated_summary_block_validator.py
@@ -12,7 +12,10 @@ class GrandCalculatedSummaryBlockValidator(CalculationBlockValidator):
         "Invalid calculated summary id in block's answers_to_calculate"
     )
     REPEATING_CALCULATED_SUMMARY_OUTSIDE_REPEAT = "Cannot have a non-repeating grand calculated summary reference a repeating calculated summary"
-    CALCULATED_SUMMARY_IN_DIFFERENT_REPEATING_SECTION = "Cannot have a repeating grand calculated summary reference a repeating calculated summary in a different repeating section"
+    CALCULATED_SUMMARY_IN_DIFFERENT_REPEATING_SECTION = (
+        "Cannot have a repeating grand calculated summary reference"
+        " a repeating calculated summary in a different repeating section"
+    )
 
     def __init__(self, block, questionnaire_schema: QuestionnaireSchema):
         super().__init__(block, questionnaire_schema)

--- a/app/validators/blocks/grand_calculated_summary_block_validator.py
+++ b/app/validators/blocks/grand_calculated_summary_block_validator.py
@@ -1,5 +1,8 @@
 from app.validators.blocks.calculation_block_validator import CalculationBlockValidator
-from app.validators.questionnaire_schema import find_dictionary_duplicates
+from app.validators.questionnaire_schema import (
+    QuestionnaireSchema,
+    find_dictionary_duplicates,
+)
 
 
 class GrandCalculatedSummaryBlockValidator(CalculationBlockValidator):
@@ -8,8 +11,10 @@ class GrandCalculatedSummaryBlockValidator(CalculationBlockValidator):
     CALCULATED_SUMMARY_HAS_INVALID_ID = (
         "Invalid calculated summary id in block's answers_to_calculate"
     )
+    REPEATING_CALCULATED_SUMMARY_OUTSIDE_REPEAT = "Cannot have a non-repeating grand calculated summary reference a repeating calculated summary"
+    CALCULATED_SUMMARY_IN_DIFFERENT_REPEATING_SECTION = "Cannot have a repeating grand calculated summary reference a repeating calculated summary in a different repeating section"
 
-    def __init__(self, block, questionnaire_schema):
+    def __init__(self, block, questionnaire_schema: QuestionnaireSchema):
         super().__init__(block, questionnaire_schema)
         self.answers_to_calculate: list[str] = []
         # check calculated summary answers sets to verify no two calculated summaries are identical
@@ -40,6 +45,7 @@ class GrandCalculatedSummaryBlockValidator(CalculationBlockValidator):
             )
 
         self.validate_answer_types(answers)
+        self.validate_repeating_calculated_summaries()
 
         return self.errors
 
@@ -68,6 +74,43 @@ class GrandCalculatedSummaryBlockValidator(CalculationBlockValidator):
             ) > self.questionnaire_schema.block_ids.index(self.block["id"]):
                 self.add_error(
                     self.CALCULATED_SUMMARY_AFTER_GRAND_CALCULATED_SUMMARY,
+                    block_id=self.block["id"],
+                    calculated_summary_id=calculated_summary_id,
+                )
+
+    def validate_repeating_calculated_summaries(self):
+        """
+        If the grand calculated summary references a repeating calculated summary, this is only valid if:
+        1) the grand calculated summary is also repeating
+        2) it is in the same repeating section as the repeating calculated summary it references
+        """
+        gcs_section_id = self.questionnaire_schema.get_section_id_for_block_id(
+            self.block["id"]
+        )
+        is_gcs_repeating = self.questionnaire_schema.is_repeating_section(
+            gcs_section_id
+        )
+        for calculated_summary_id in self.calculated_summaries_to_calculate:
+            if not self.questionnaire_schema.is_block_in_repeating_section(
+                calculated_summary_id
+            ):
+                # validation below only required for repeating calculated summaries
+                continue
+
+            if not is_gcs_repeating:
+                self.add_error(
+                    self.REPEATING_CALCULATED_SUMMARY_OUTSIDE_REPEAT,
+                    block_id=self.block["id"],
+                    calculated_summary_id=calculated_summary_id,
+                )
+            elif (
+                gcs_section_id
+                != self.questionnaire_schema.get_section_id_for_block_id(
+                    calculated_summary_id
+                )
+            ):
+                self.add_error(
+                    self.CALCULATED_SUMMARY_IN_DIFFERENT_REPEATING_SECTION,
                     block_id=self.block["id"],
                     calculated_summary_id=calculated_summary_id,
                 )

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -544,7 +544,7 @@ class QuestionnaireSchema:
     def get_section_block_ids(self, current_section=None):
         return [block["id"] for block in self.blocks_by_section_id[current_section]]
 
-    def get_section_id_for_block(self, block) -> str | None:
+    def get_section_id_for_block(self, block: Mapping) -> str | None:
         for section_id, blocks in self.blocks_by_section_id.items():
             if block in blocks:
                 return section_id

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -544,7 +544,11 @@ class QuestionnaireSchema:
     def get_section_block_ids(self, current_section=None):
         return [block["id"] for block in self.blocks_by_section_id[current_section]]
 
-    def get_section_id_for_block(self, block):
+    def get_section_id_for_block(self, block) -> str | None:
         for section_id, blocks in self.blocks_by_section_id.items():
             if block in blocks:
                 return section_id
+
+    def get_section_id_for_block_id(self, block_id: str) -> str | None:
+        if block := self.get_block(block_id):
+            return self.get_section_id_for_block(block)

--- a/app/validators/validator.py
+++ b/app/validators/validator.py
@@ -1,9 +1,9 @@
 from abc import ABC
-from typing import List
+from typing import Mapping
 
 
 class Validator(ABC):
-    def __init__(self, schema_element=None):
+    def __init__(self, schema_element: Mapping | None = None):
         self.errors = []
         self.context = {}
         self.schema_element = schema_element or {}
@@ -11,5 +11,5 @@ class Validator(ABC):
     def add_error(self, message, **context):
         self.errors.append({"message": message, **context, **self.context})
 
-    def validate(self) -> List[dict]:
+    def validate(self) -> list[dict]:
         return self.errors

--- a/tests/schemas/invalid/test_invalid_grand_calculated_summary_inside_repeating_section.json
+++ b/tests/schemas/invalid/test_invalid_grand_calculated_summary_inside_repeating_section.json
@@ -1,0 +1,841 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Grand Calculated Summary Inside Repeating Section",
+  "theme": "default",
+  "description": "An invalid schema with a grand calculated summary in a repeat referencing a separate repeating calculated summary",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Hub",
+    "options": {}
+  },
+  "sections": [
+    {
+      "id": "base-costs-section",
+      "title": "Vehicle Costs",
+      "summary": {
+        "show_on_completion": true
+      },
+      "groups": [
+        {
+          "id": "base-costs-group",
+          "blocks": [
+            {
+              "type": "ListCollectorDrivingQuestion",
+              "id": "any-cost",
+              "for_list": "costs",
+              "question": {
+                "type": "General",
+                "id": "any-cost-question",
+                "title": "Do you have any outgoing costs for owning a vehicle?",
+                "answers": [
+                  {
+                    "type": "Radio",
+                    "id": "any-cost-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock",
+                          "params": {
+                            "block_id": "add-cost",
+                            "list_name": "costs"
+                          }
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "routing_rules": [
+                {
+                  "block": "finance-cost",
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "any-cost-answer"
+                      },
+                      "No"
+                    ]
+                  }
+                },
+                {
+                  "block": "list-collector-cost"
+                }
+              ]
+            },
+            {
+              "id": "list-collector-cost",
+              "type": "ListCollector",
+              "for_list": "costs",
+              "question": {
+                "id": "confirmation-cost-question",
+                "type": "General",
+                "title": "Do you need to add other outgoing costs?",
+                "answers": [
+                  {
+                    "id": "list-collector-cost-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-cost",
+                "type": "ListAddQuestion",
+                "cancel_text": "Don’t need to add any other outgoing costs?",
+                "question": {
+                  "id": "add-cost-question",
+                  "type": "General",
+                  "title": "What outgoing cost do you have?",
+                  "answers": [
+                    {
+                      "id": "cost-name",
+                      "label": "Outgoing cost",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Road Tax",
+                          "value": "Road Tax"
+                        },
+                        {
+                          "label": "Parking Permit",
+                          "value": "Parking Permit"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-cost",
+                "type": "ListEditQuestion",
+                "cancel_text": "Don’t need to change anything?",
+                "question": {
+                  "id": "edit-cost-question",
+                  "type": "General",
+                  "title": "What outgoing cost do you have?",
+                  "answers": [
+                    {
+                      "id": "cost-name",
+                      "label": "Outgoing cost",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Road Tax",
+                          "value": "Road Tax"
+                        },
+                        {
+                          "label": "Parking Permit",
+                          "value": "Parking Permit"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-cost",
+                "type": "ListRemoveQuestion",
+                "cancel_text": "Don’t need to remove this outgoing cost?",
+                "question": {
+                  "id": "remove-cost-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this outgoing cost?",
+                  "warning": "All of the information about this outgoing cost will be deleted",
+                  "answers": [
+                    {
+                      "id": "remove-cost-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "cost",
+                "item_title": {
+                  "text": "{cost_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "cost_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "cost-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "base-cost-details-section",
+      "title": "Cost Details",
+      "summary": {
+        "show_on_completion": true
+      },
+      "repeat": {
+        "for_list": "costs",
+        "title": {
+          "text": "{cost} details",
+          "placeholders": [
+            {
+              "placeholder": "cost",
+              "value": {
+                "source": "answers",
+                "identifier": "cost-name"
+              }
+            }
+          ]
+        }
+      },
+      "groups": [
+        {
+          "id": "cost-details-group",
+          "blocks": [
+            {
+              "id": "cost-details-block",
+              "type": "Question",
+              "question": {
+                "id": "cost-details-question",
+                "type": "General",
+                "title": {
+                  "text": "What do you spend monthly on {cost}?",
+                  "placeholders": [
+                    {
+                      "placeholder": "cost",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "cost-name"
+                      }
+                    }
+                  ]
+                },
+                "answers": [
+                  {
+                    "id": "cost-details-cost",
+                    "label": {
+                      "text": "{cost} personal expenditure",
+                      "placeholders": [
+                        {
+                          "placeholder": "cost",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "cost-name"
+                          }
+                        }
+                      ]
+                    },
+                    "mandatory": true,
+                    "type": "Currency",
+                    "currency": "GBP",
+                    "decimal_places": 2
+                  }
+                ]
+              }
+            },
+            {
+              "id": "cost-partner-block",
+              "type": "Question",
+              "question": {
+                "id": "cost-partner-question",
+                "type": "General",
+                "title": {
+                  "text": "What does your partner spend monthly on {cost}?",
+                  "placeholders": [
+                    {
+                      "placeholder": "cost",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "cost-name"
+                      }
+                    }
+                  ]
+                },
+                "answers": [
+                  {
+                    "id": "cost-partner-cost",
+                    "label": {
+                      "text": "{cost} partner expenditure",
+                      "placeholders": [
+                        {
+                          "placeholder": "cost",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "cost-name"
+                          }
+                        }
+                      ]
+                    },
+                    "mandatory": true,
+                    "type": "Currency",
+                    "currency": "GBP",
+                    "decimal_places": 2
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CalculatedSummary",
+              "id": "calculated-summary-base-cost",
+              "title": {
+                "text": "We calculate the household expenditure on {cost} to be %(total)s. Is this correct?",
+                "placeholders": [
+                  {
+                    "placeholder": "cost",
+                    "value": {
+                      "source": "answers",
+                      "identifier": "cost-name"
+                    }
+                  }
+                ]
+              },
+              "calculation": {
+                "title": {
+                  "text": "Monthly {cost} expenditure",
+                  "placeholders": [
+                    {
+                      "placeholder": "cost",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "cost-name"
+                      }
+                    }
+                  ]
+                },
+                "operation": {
+                  "+": [
+                    {
+                      "source": "answers",
+                      "identifier": "cost-details-cost"
+                    },
+                    {
+                      "source": "answers",
+                      "identifier": "cost-partner-cost"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vehicles-section",
+      "title": "Vehicle Ownership",
+      "summary": {
+        "show_on_completion": true,
+        "items": [
+          {
+            "type": "List",
+            "for_list": "vehicles",
+            "title": "Vehicles",
+            "add_link_text": "Add another vehicle",
+            "empty_list_text": "There are no vehicles"
+          }
+        ],
+        "show_non_item_answers": true
+      },
+      "groups": [
+        {
+          "id": "vehicles-group",
+          "blocks": [
+            {
+              "type": "ListCollectorDrivingQuestion",
+              "id": "any-vehicle",
+              "for_list": "vehicles",
+              "question": {
+                "type": "General",
+                "id": "any-vehicle-question",
+                "title": "Do you own any vehicles?",
+                "answers": [
+                  {
+                    "type": "Radio",
+                    "id": "any-vehicle-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock",
+                          "params": {
+                            "block_id": "add-vehicle",
+                            "list_name": "vehicles"
+                          }
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "routing_rules": [
+                {
+                  "section": "End",
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "any-vehicle-answer"
+                      },
+                      "No"
+                    ]
+                  }
+                },
+                {
+                  "block": "list-collector"
+                }
+              ]
+            },
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "for_list": "vehicles",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Do you need to add more vehicles?",
+                "answers": [
+                  {
+                    "id": "list-collector-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-vehicle",
+                "type": "ListAddQuestion",
+                "cancel_text": "Don’t need to add any other vehicles?",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What vehicle do you own?",
+                  "answers": [
+                    {
+                      "id": "vehicle-name",
+                      "label": "Vehicle",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Car",
+                          "value": "Car"
+                        },
+                        {
+                          "label": "Motorbike",
+                          "value": "Motorbike"
+                        },
+                        {
+                          "label": "Van",
+                          "value": "Van"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-vehicle",
+                "type": "ListEditQuestion",
+                "cancel_text": "Don’t need to change anything?",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What vehicle do you own?",
+                  "answers": [
+                    {
+                      "id": "vehicle-name",
+                      "label": "Vehicle",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Car",
+                          "value": "Car"
+                        },
+                        {
+                          "label": "Motorbike",
+                          "value": "Motorbike"
+                        },
+                        {
+                          "label": "Van",
+                          "value": "Van"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-vehicle",
+                "type": "ListRemoveQuestion",
+                "cancel_text": "Don’t need to remove this vehicle?",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this vehicle?",
+                  "warning": "All of the information about this vehicle will be deleted",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "Vehicle",
+                "item_title": {
+                  "text": "{vehicle_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "vehicle-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vehicle-details-section",
+      "title": "Vehicle Details",
+      "summary": {
+        "show_on_completion": true
+      },
+      "repeat": {
+        "for_list": "vehicles",
+        "title": {
+          "text": "{vehicle_name} details",
+          "placeholders": [
+            {
+              "placeholder": "vehicle_name",
+              "value": {
+                "source": "answers",
+                "identifier": "vehicle-name"
+              }
+            }
+          ]
+        }
+      },
+      "groups": [
+        {
+          "id": "vehicle-details-group",
+          "blocks": [
+            {
+              "id": "vehicle-maintenance-block",
+              "type": "Question",
+              "question": {
+                "id": "vehicle-maintenance-question",
+                "type": "General",
+                "title": {
+                  "text": "What is your monthly expenditure on maintenance for your {vehicle_name}?",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "vehicle-name"
+                      }
+                    }
+                  ]
+                },
+                "answers": [
+                  {
+                    "id": "vehicle-maintenance-cost",
+                    "label": {
+                      "text": "{vehicle_name} maintenance costs",
+                      "placeholders": [
+                        {
+                          "placeholder": "vehicle_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "vehicle-name"
+                          }
+                        }
+                      ]
+                    },
+                    "mandatory": true,
+                    "type": "Currency",
+                    "currency": "GBP",
+                    "decimal_places": 2
+                  }
+                ]
+              }
+            },
+            {
+              "id": "vehicle-fuel-block",
+              "type": "Question",
+              "question": {
+                "id": "vehicle-fuel-question",
+                "type": "General",
+                "title": {
+                  "text": "What is your monthly expenditure on fuel for your {vehicle_name}?",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "vehicle-name"
+                      }
+                    }
+                  ]
+                },
+                "answers": [
+                  {
+                    "id": "vehicle-fuel-cost",
+                    "label": {
+                      "text": "{vehicle_name} fuel costs",
+                      "placeholders": [
+                        {
+                          "placeholder": "vehicle_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "vehicle-name"
+                          }
+                        }
+                      ]
+                    },
+                    "mandatory": true,
+                    "type": "Currency",
+                    "currency": "GBP",
+                    "decimal_places": 2
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CalculatedSummary",
+              "id": "calculated-summary-running-cost",
+              "title": {
+                "text": "We calculate the monthly running costs of your {vehicle_name} to be %(total)s. Is this correct?",
+                "placeholders": [
+                  {
+                    "placeholder": "vehicle_name",
+                    "value": {
+                      "source": "answers",
+                      "identifier": "vehicle-name"
+                    }
+                  }
+                ]
+              },
+              "calculation": {
+                "title": {
+                  "text": "Monthly {vehicle_name} costs",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "vehicle-name"
+                      }
+                    }
+                  ]
+                },
+                "operation": {
+                  "+": [
+                    {
+                      "source": "answers",
+                      "identifier": "vehicle-maintenance-cost"
+                    },
+                    {
+                      "source": "answers",
+                      "identifier": "vehicle-fuel-cost"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "GrandCalculatedSummary",
+              "id": "grand-calculated-summary-vehicle",
+              "title": {
+                "text": "The total cost of owning and running your {vehicle_name} is calculated to be %(total)s. Is this correct?",
+                "placeholders": [
+                  {
+                    "placeholder": "vehicle_name",
+                    "value": {
+                      "source": "answers",
+                      "identifier": "vehicle-name"
+                    }
+                  }
+                ]
+              },
+              "calculation": {
+                "operation": {
+                  "+": [
+                    {
+                      "source": "calculated_summary",
+                      "identifier": "calculated-summary-base-cost"
+                    },
+                    {
+                      "source": "calculated_summary",
+                      "identifier": "calculated-summary-running-cost"
+                    }
+                  ]
+                },
+                "title": {
+                  "text": "Grand total {vehicle_name} expenditure",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "vehicle-name"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "invalid-grand-calculated-summary-section",
+      "title": "Invalid Grand Calculated Summary",
+      "groups": [
+        {
+          "id": "invalid-gcs-group",
+          "blocks": [
+            {
+              "type": "GrandCalculatedSummary",
+              "id": "grand-calculated-invalid-outside-repeat",
+              "title": "The total cost of owning and running all vehicles is calculated to be %(total)s. Is this correct?",
+              "calculation": {
+                "operation": {
+                  "+": [
+                    {
+                      "source": "calculated_summary",
+                      "identifier": "calculated-summary-base-cost"
+                    },
+                    {
+                      "source": "calculated_summary",
+                      "identifier": "calculated-summary-running-cost"
+                    }
+                  ]
+                },
+                "title": "Grand total expenditure"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/valid/test_grand_calculated_summary_inside_repeating_section.json
+++ b/tests/schemas/valid/test_grand_calculated_summary_inside_repeating_section.json
@@ -1,0 +1,760 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Grand Calculated Summary Inside Repeating Section",
+  "theme": "default",
+  "description": "A schema to showcase a grand calculated summary inside a repeating section",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Hub",
+    "options": {}
+  },
+  "sections": [
+    {
+      "id": "base-costs-section",
+      "title": "Vehicle Costs",
+      "summary": {
+        "show_on_completion": true
+      },
+      "groups": [
+        {
+          "id": "base-costs-group",
+          "blocks": [
+            {
+              "type": "ListCollectorDrivingQuestion",
+              "id": "any-cost",
+              "for_list": "costs",
+              "question": {
+                "type": "General",
+                "id": "any-cost-question",
+                "title": "Do you have any outgoing costs for owning a vehicle?",
+                "guidance": {
+                  "contents": [
+                    {
+                      "title": "Notes for testing"
+                    },
+                    {
+                      "description": "For the first iteration, calculated summaries of repeating answers don’t work in a grand calculated summary in a separate repeating section"
+                    },
+                    {
+                      "description": "<b>So you should answer no to this question</b> and remove this guidance once separate repeating answer calculated summaries are supported"
+                    }
+                  ]
+                },
+                "answers": [
+                  {
+                    "type": "Radio",
+                    "id": "any-cost-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock",
+                          "params": {
+                            "block_id": "add-cost",
+                            "list_name": "costs"
+                          }
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "routing_rules": [
+                {
+                  "block": "finance-cost",
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "any-cost-answer"
+                      },
+                      "No"
+                    ]
+                  }
+                },
+                {
+                  "block": "list-collector-cost"
+                }
+              ]
+            },
+            {
+              "id": "list-collector-cost",
+              "type": "ListCollector",
+              "for_list": "costs",
+              "question": {
+                "id": "confirmation-cost-question",
+                "type": "General",
+                "title": "Do you need to add other outgoing costs?",
+                "answers": [
+                  {
+                    "id": "list-collector-cost-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-cost",
+                "type": "ListAddQuestion",
+                "cancel_text": "Don’t need to add any other outgoing costs?",
+                "question": {
+                  "id": "add-cost-question",
+                  "type": "General",
+                  "title": "What outgoing cost do you have?",
+                  "answers": [
+                    {
+                      "id": "cost-name",
+                      "label": "Outgoing cost",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Road Tax",
+                          "value": "Road Tax"
+                        },
+                        {
+                          "label": "Parking Permit",
+                          "value": "Parking Permit"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-cost",
+                "type": "ListEditQuestion",
+                "cancel_text": "Don’t need to change anything?",
+                "question": {
+                  "id": "edit-cost-question",
+                  "type": "General",
+                  "title": "What outgoing cost do you have?",
+                  "answers": [
+                    {
+                      "id": "cost-name",
+                      "label": "Outgoing cost",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Road Tax",
+                          "value": "Road Tax"
+                        },
+                        {
+                          "label": "Parking Permit",
+                          "value": "Parking Permit"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-cost",
+                "type": "ListRemoveQuestion",
+                "cancel_text": "Don’t need to remove this outgoing cost?",
+                "question": {
+                  "id": "remove-cost-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this outgoing cost?",
+                  "warning": "All of the information about this outgoing cost will be deleted",
+                  "answers": [
+                    {
+                      "id": "remove-cost-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "cost",
+                "item_title": {
+                  "text": "{cost_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "cost_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "cost-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "Question",
+              "id": "dynamic-cost-block",
+              "skip_conditions": {
+                "when": {
+                  "==": [
+                    {
+                      "count": [
+                        {
+                          "source": "list",
+                          "identifier": "costs"
+                        }
+                      ]
+                    },
+                    0
+                  ]
+                }
+              },
+              "question": {
+                "id": "dynamic-answer-question",
+                "title": "How much do you spend per month on the following for a single vehicle?",
+                "type": "General",
+                "dynamic_answers": {
+                  "values": {
+                    "source": "list",
+                    "identifier": "costs"
+                  },
+                  "answers": [
+                    {
+                      "label": {
+                        "text": "Single vehicle {transformed_value}",
+                        "placeholders": [
+                          {
+                            "placeholder": "transformed_value",
+                            "value": {
+                              "source": "answers",
+                              "identifier": "cost-name"
+                            }
+                          }
+                        ]
+                      },
+                      "id": "cost-of-cost",
+                      "type": "Currency",
+                      "mandatory": true,
+                      "currency": "GBP",
+                      "decimal_places": 2
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "id": "finance-cost",
+              "type": "Question",
+              "question": {
+                "id": "finance-cost-question",
+                "type": "General",
+                "title": "What is your monthly expenditure per vehicle on finance?",
+                "answers": [
+                  {
+                    "id": "finance-cost-answer",
+                    "label": "Vehicle monthly finance costs",
+                    "mandatory": true,
+                    "type": "Currency",
+                    "currency": "GBP",
+                    "decimal_places": 2
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CalculatedSummary",
+              "id": "calculated-summary-base-cost",
+              "title": "We calculate the total base cost for any owned vehicle to be %(total)s. Is this correct?",
+              "calculation": {
+                "title": "Vehicle base cost",
+                "operation": {
+                  "+": [
+                    {
+                      "source": "answers",
+                      "identifier": "cost-of-cost"
+                    },
+                    {
+                      "source": "answers",
+                      "identifier": "finance-cost-answer"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vehicles-section",
+      "title": "Vehicle Ownership",
+      "summary": {
+        "show_on_completion": true,
+        "items": [
+          {
+            "type": "List",
+            "for_list": "vehicles",
+            "title": "Vehicles",
+            "add_link_text": "Add another vehicle",
+            "empty_list_text": "There are no vehicles"
+          }
+        ],
+        "show_non_item_answers": true
+      },
+      "groups": [
+        {
+          "id": "vehicles-group",
+          "blocks": [
+            {
+              "type": "ListCollectorDrivingQuestion",
+              "id": "any-vehicle",
+              "for_list": "vehicles",
+              "question": {
+                "type": "General",
+                "id": "any-vehicle-question",
+                "title": "Do you own any vehicles?",
+                "answers": [
+                  {
+                    "type": "Radio",
+                    "id": "any-vehicle-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock",
+                          "params": {
+                            "block_id": "add-vehicle",
+                            "list_name": "vehicles"
+                          }
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "routing_rules": [
+                {
+                  "section": "End",
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "any-vehicle-answer"
+                      },
+                      "No"
+                    ]
+                  }
+                },
+                {
+                  "block": "list-collector"
+                }
+              ]
+            },
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "for_list": "vehicles",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Do you need to add more vehicles?",
+                "answers": [
+                  {
+                    "id": "list-collector-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-vehicle",
+                "type": "ListAddQuestion",
+                "cancel_text": "Don’t need to add any other vehicles?",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What vehicle do you own?",
+                  "answers": [
+                    {
+                      "id": "vehicle-name",
+                      "label": "Vehicle",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Car",
+                          "value": "Car"
+                        },
+                        {
+                          "label": "Motorbike",
+                          "value": "Motorbike"
+                        },
+                        {
+                          "label": "Van",
+                          "value": "Van"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-vehicle",
+                "type": "ListEditQuestion",
+                "cancel_text": "Don’t need to change anything?",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What vehicle do you own?",
+                  "answers": [
+                    {
+                      "id": "vehicle-name",
+                      "label": "Vehicle",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Car",
+                          "value": "Car"
+                        },
+                        {
+                          "label": "Motorbike",
+                          "value": "Motorbike"
+                        },
+                        {
+                          "label": "Van",
+                          "value": "Van"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-vehicle",
+                "type": "ListRemoveQuestion",
+                "cancel_text": "Don’t need to remove this vehicle?",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this vehicle?",
+                  "warning": "All of the information about this vehicle will be deleted",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "Vehicle",
+                "item_title": {
+                  "text": "{vehicle_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "vehicle-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "vehicle-details-section",
+      "title": "Vehicle Details",
+      "summary": {
+        "show_on_completion": true
+      },
+      "repeat": {
+        "for_list": "vehicles",
+        "title": {
+          "text": "{vehicle_name} details",
+          "placeholders": [
+            {
+              "placeholder": "vehicle_name",
+              "value": {
+                "source": "answers",
+                "identifier": "vehicle-name"
+              }
+            }
+          ]
+        }
+      },
+      "groups": [
+        {
+          "id": "vehicle-details-group",
+          "blocks": [
+            {
+              "id": "vehicle-maintenance-block",
+              "type": "Question",
+              "question": {
+                "id": "vehicle-maintenance-question",
+                "type": "General",
+                "title": {
+                  "text": "What is your monthly expenditure on maintenance for your {vehicle_name}?",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "vehicle-name"
+                      }
+                    }
+                  ]
+                },
+                "answers": [
+                  {
+                    "id": "vehicle-maintenance-cost",
+                    "label": {
+                      "text": "{vehicle_name} maintenance costs",
+                      "placeholders": [
+                        {
+                          "placeholder": "vehicle_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "vehicle-name"
+                          }
+                        }
+                      ]
+                    },
+                    "mandatory": true,
+                    "type": "Currency",
+                    "currency": "GBP",
+                    "decimal_places": 2
+                  }
+                ]
+              }
+            },
+            {
+              "id": "vehicle-fuel-block",
+              "type": "Question",
+              "question": {
+                "id": "vehicle-fuel-question",
+                "type": "General",
+                "title": {
+                  "text": "What is your monthly expenditure on fuel for your {vehicle_name}?",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "vehicle-name"
+                      }
+                    }
+                  ]
+                },
+                "answers": [
+                  {
+                    "id": "vehicle-fuel-cost",
+                    "label": {
+                      "text": "{vehicle_name} fuel costs",
+                      "placeholders": [
+                        {
+                          "placeholder": "vehicle_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "vehicle-name"
+                          }
+                        }
+                      ]
+                    },
+                    "mandatory": true,
+                    "type": "Currency",
+                    "currency": "GBP",
+                    "decimal_places": 2
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CalculatedSummary",
+              "id": "calculated-summary-running-cost",
+              "title": {
+                "text": "We calculate the monthly running costs of your {vehicle_name} to be %(total)s. Is this correct?",
+                "placeholders": [
+                  {
+                    "placeholder": "vehicle_name",
+                    "value": {
+                      "source": "answers",
+                      "identifier": "vehicle-name"
+                    }
+                  }
+                ]
+              },
+              "calculation": {
+                "title": {
+                  "text": "Monthly {vehicle_name} costs",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "vehicle-name"
+                      }
+                    }
+                  ]
+                },
+                "operation": {
+                  "+": [
+                    {
+                      "source": "answers",
+                      "identifier": "vehicle-maintenance-cost"
+                    },
+                    {
+                      "source": "answers",
+                      "identifier": "vehicle-fuel-cost"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "GrandCalculatedSummary",
+              "id": "grand-calculated-summary-vehicle",
+              "title": {
+                "text": "The total cost of owning and running your {vehicle_name} is calculated to be %(total)s. Is this correct?",
+                "placeholders": [
+                  {
+                    "placeholder": "vehicle_name",
+                    "value": {
+                      "source": "answers",
+                      "identifier": "vehicle-name"
+                    }
+                  }
+                ]
+              },
+              "calculation": {
+                "operation": {
+                  "+": [
+                    {
+                      "source": "calculated_summary",
+                      "identifier": "calculated-summary-base-cost"
+                    },
+                    {
+                      "source": "calculated_summary",
+                      "identifier": "calculated-summary-running-cost"
+                    }
+                  ]
+                },
+                "title": {
+                  "text": "Grand total {vehicle_name} expenditure",
+                  "placeholders": [
+                    {
+                      "placeholder": "vehicle_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "vehicle-name"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/validators/blocks/test_grand_calculated_summary_block_validator.py
+++ b/tests/validators/blocks/test_grand_calculated_summary_block_validator.py
@@ -78,3 +78,50 @@ def test_invalid_grand_calculated_summary_before_calculated_summary():
     errors += validator.validate()
 
     assert errors == expected_error_messages
+
+
+def test_invalid_repeating_grand_calculated_summary_referencing_repeating_calculated_summary():
+    """Asserts `invalid` when a repeating GCS references a repeating CS from a different repeating section"""
+    filename = "schemas/invalid/test_invalid_grand_calculated_summary_inside_repeating_section.json"
+    json_to_validate = _open_and_load_schema_file(filename)
+
+    expected_error_messages = [
+        {
+            "calculated_summary_id": "calculated-summary-base-cost",
+            "block_id": "grand-calculated-summary-vehicle",
+            "message": GrandCalculatedSummaryBlockValidator.CALCULATED_SUMMARY_IN_DIFFERENT_REPEATING_SECTION,
+        }
+    ]
+
+    questionnaire_schema = QuestionnaireSchema(json_to_validate)
+    block = questionnaire_schema.get_block("grand-calculated-summary-vehicle")
+    validator = GrandCalculatedSummaryBlockValidator(block, questionnaire_schema)
+    errors = validator.validate()
+
+    assert errors == expected_error_messages
+
+
+def test_invalid_non_repeating_grand_calculated_summary_referencing_repeating_calculated_summary():
+    """Asserts `invalid` when a non-repeating GCS references a repeating CS"""
+    filename = "schemas/invalid/test_invalid_grand_calculated_summary_inside_repeating_section.json"
+    json_to_validate = _open_and_load_schema_file(filename)
+
+    expected_error_messages = [
+        {
+            "calculated_summary_id": "calculated-summary-base-cost",
+            "block_id": "grand-calculated-invalid-outside-repeat",
+            "message": GrandCalculatedSummaryBlockValidator.REPEATING_CALCULATED_SUMMARY_OUTSIDE_REPEAT,
+        },
+        {
+            "calculated_summary_id": "calculated-summary-running-cost",
+            "block_id": "grand-calculated-invalid-outside-repeat",
+            "message": GrandCalculatedSummaryBlockValidator.REPEATING_CALCULATED_SUMMARY_OUTSIDE_REPEAT,
+        },
+    ]
+
+    questionnaire_schema = QuestionnaireSchema(json_to_validate)
+    block = questionnaire_schema.get_block("grand-calculated-invalid-outside-repeat")
+    validator = GrandCalculatedSummaryBlockValidator(block, questionnaire_schema)
+    errors = validator.validate()
+
+    assert errors == expected_error_messages


### PR DESCRIPTION
### What is the context of this PR?
This PR adds validation for grand calculated summaries which reference a repeating calculated summary. This combination is only valid if the grand calculated summary and calculated summary reside in the same repeating section. 

A non-repeating GCS cannot reference a repeating CS and a repeating GCS cannot reference a repeating CS in a separate repeating section.

This is the validator component of the [corresponding runner PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/1210)

### How to review
Check that the invalid schema correctly covers both of the invalid cases and that the valid schema added is the correct usee of a grand calculated summary in a repeating section referencing calculated summaries in the same repeat and non-repeating calculated summaries in different sections.

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
