### PR TITLE
Update github actions to use nvmrc file for node versioning

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.14.2"
+          node-version-file: ".nvmrc"
           cache: "yarn"
       - run: |
           echo "PYTHON_VERSION=$(python -c 'import platform; print(platform.python_version())')" >> $GITHUB_ENV
@@ -55,7 +55,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.14.2"
+          node-version-file: ".nvmrc"
           cache: "yarn"
       - run: |
           echo "PYTHON_VERSION=$(python -c 'import platform; print(platform.python_version())')" >> $GITHUB_ENV


### PR DESCRIPTION
### What is the context of this PR?
Updated GitHub Actions to use the `.nvmrc` file instead of hard-coding the `Node.js` version.

### How to review
Check if github actions is fetching the version from the `.nvmrc`file

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
