### PR TITLE
Add list source reference order validation

### DIFF
--- a/app/error_messages.py
+++ b/app/error_messages.py
@@ -40,6 +40,4 @@ VARIANTS_HAVE_MULTIPLE_QUESTION_TYPES = (
     "Variants have more than one question type for block."
 )
 PREVIEW_WITHOUT_INTRODUCTION_BLOCK = "No introduction block found. Introduction block is mandatory when using the preview questions feature."
-LIST_REFERENCED_BEFORE_ADDED = (
-    "List '{list_name}' referenced as source before it has been created."
-)
+LIST_REFERENCED_BEFORE_ADDED = "List referenced as source before it has been created."

--- a/app/error_messages.py
+++ b/app/error_messages.py
@@ -40,3 +40,6 @@ VARIANTS_HAVE_MULTIPLE_QUESTION_TYPES = (
     "Variants have more than one question type for block."
 )
 PREVIEW_WITHOUT_INTRODUCTION_BLOCK = "No introduction block found. Introduction block is mandatory when using the preview questions feature."
+LIST_REFERENCED_BEFORE_ADDED = (
+    "List '{list_name}' referenced as source before it has been created."
+)

--- a/app/error_messages.py
+++ b/app/error_messages.py
@@ -40,4 +40,4 @@ VARIANTS_HAVE_MULTIPLE_QUESTION_TYPES = (
     "Variants have more than one question type for block."
 )
 PREVIEW_WITHOUT_INTRODUCTION_BLOCK = "No introduction block found. Introduction block is mandatory when using the preview questions feature."
-LIST_REFERENCED_BEFORE_ADDED = "List referenced as source before it has been created."
+LIST_REFERENCED_BEFORE_CREATED = "List referenced as source before it has been created."

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -227,7 +227,7 @@ class QuestionnaireSchema:
                 list_id = block["for_list"]
                 if list_id not in self._lists_with_context:
                     section_id = self.get_section_id_for_block_id(block["id"])
-                    section_index = self.get_section_index_for_section_id(section_id)
+                    section_index = self.section_ids.index(section_id)
                     self._lists_with_context[list_id] = {
                         "section_index": section_index,
                         "block_index": self.block_ids.index(block["id"]),
@@ -240,7 +240,7 @@ class QuestionnaireSchema:
                     < self._lists_with_context[list_id]["block_index"]
                 ):
                     section_id = self.get_section_id_for_block_id(block["id"])
-                    section_index = self.get_section_index_for_section_id(section_id)
+                    section_index = self.section_ids.index(section_id)
                     self._lists_with_context[list_id] = {
                         "section_index": section_index,
                         "block_index": self.block_ids.index(block["id"]),
@@ -656,26 +656,3 @@ class QuestionnaireSchema:
     def get_section_id_for_block_id(self, block_id: str) -> str | None:
         if block := self.get_block(block_id):
             return self.get_section_id_for_block(block)
-
-    def get_list_collector_block_id_for_add_block(self, block_id) -> dict | None:
-        for block in self.blocks:
-            if (
-                block["type"] == "ListCollector"
-                and block["add_block"]["id"] == block_id
-            ):
-                return block["id"]
-
-    def get_list_collector_block_id_for_repeating_blocks(self, block_id) -> dict | None:
-        for block in self.blocks:
-            if block["type"] in [
-                "ListCollector",
-                "ListCollectorContent",
-            ] and block.get("repeating_blocks"):
-                for repeating_block in block["repeating_blocks"]:
-                    if repeating_block["id"] == block_id:
-                        return block["id"]
-
-    def get_section_index_for_section_id(self, section_id: str) -> int:
-        for index, section in enumerate(self.sections):
-            if section["id"] == section_id:
-                return index

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -619,24 +619,22 @@ class QuestionnaireSchema:
             return self.get_section_id_for_block(block)
 
     def get_list_collector_block_id_for_add_block(self, block_id) -> dict | None:
-        for section_id, blocks in self.blocks_by_section_id.items():
-            for block in blocks:
-                if (
-                    block["type"] == "ListCollector"
-                    and block["add_block"]["id"] == block_id
-                ):
-                    return block["id"]
+        for block in self.blocks:
+            if (
+                block["type"] == "ListCollector"
+                and block["add_block"]["id"] == block_id
+            ):
+                return block["id"]
 
     def get_list_collector_block_id_for_repeating_blocks(self, block_id) -> dict | None:
-        for section_id, blocks in self.blocks_by_section_id.items():
-            for block in blocks:
-                if block["type"] in [
-                    "ListCollector",
-                    "ListCollectorContent",
-                ] and block.get("repeating_blocks"):
-                    for repeating_block in block["repeating_blocks"]:
-                        if repeating_block["id"] == block_id:
-                            return block["id"]
+        for block in self.blocks:
+            if block["type"] in [
+                "ListCollector",
+                "ListCollectorContent",
+            ] and block.get("repeating_blocks"):
+                for repeating_block in block["repeating_blocks"]:
+                    if repeating_block["id"] == block_id:
+                        return block["id"]
 
     def resolve_parent_block_index_for_source(self, parent_block_id: str) -> int:
         if (
@@ -645,15 +643,15 @@ class QuestionnaireSchema:
         ):
             return self.block_ids.index(parent_block_id)
 
-        elif list_collector_id := self.get_list_collector_block_id_for_add_block(
+        if list_collector_id := self.get_list_collector_block_id_for_add_block(
             parent_block_id
         ):
             return self.block_ids.index(list_collector_id)
 
-        elif list_collector_with_repeating_blocks_id := self.get_list_collector_block_id_for_repeating_blocks(
-            parent_block_id
-        ):
-            return self.block_ids.index(list_collector_with_repeating_blocks_id)
+        list_collector_with_repeating_blocks_id = (
+            self.get_list_collector_block_id_for_repeating_blocks(parent_block_id)
+        )
+        return self.block_ids.index(list_collector_with_repeating_blocks_id)
 
     def get_section_index_for_section_id(self, section_id: str) -> int:
         for index, section in enumerate(self.sections):

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -212,9 +212,6 @@ class QuestionnaireSchema:
 
     @property
     def lists_with_context(self):
-        if self._lists_with_context:
-            return self._lists_with_context
-
         if supplementary_list := self.supplementary_lists:
             for list_id in supplementary_list:
                 self._lists_with_context[list_id] = {

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -617,3 +617,8 @@ class QuestionnaireSchema:
     def get_section_id_for_block_id(self, block_id: str) -> str | None:
         if block := self.get_block(block_id):
             return self.get_section_id_for_block(block)
+
+    def get_section_index_for_section_id(self, section_id: str) -> int:
+        for index, section in enumerate(self.sections):
+            if section["id"] == section_id:
+                return index

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -618,6 +618,43 @@ class QuestionnaireSchema:
         if block := self.get_block(block_id):
             return self.get_section_id_for_block(block)
 
+    def get_list_collector_block_id_for_add_block(self, block_id) -> dict | None:
+        for section_id, blocks in self.blocks_by_section_id.items():
+            for block in blocks:
+                if (
+                    block["type"] == "ListCollector"
+                    and block["add_block"]["id"] == block_id
+                ):
+                    return block["id"]
+
+    def get_list_collector_block_id_for_repeating_blocks(self, block_id) -> dict | None:
+        for section_id, blocks in self.blocks_by_section_id.items():
+            for block in blocks:
+                if block["type"] in [
+                    "ListCollector",
+                    "ListCollectorContent",
+                ] and block.get("repeating_blocks"):
+                    for repeating_block in block["repeating_blocks"]:
+                        if repeating_block["id"] == block_id:
+                            return block["id"]
+
+    def resolve_parent_block_index_for_source(self, parent_block_id: str) -> int:
+        if (
+            self.block_ids.index(parent_block_id)
+            or self.block_ids.index(parent_block_id) == 0
+        ):
+            return self.block_ids.index(parent_block_id)
+
+        elif list_collector_id := self.get_list_collector_block_id_for_add_block(
+            parent_block_id
+        ):
+            return self.block_ids.index(list_collector_id)
+
+        elif list_collector_with_repeating_blocks_id := self.get_list_collector_block_id_for_repeating_blocks(
+            parent_block_id
+        ):
+            return self.block_ids.index(list_collector_with_repeating_blocks_id)
+
     def get_section_index_for_section_id(self, section_id: str) -> int:
         for index, section in enumerate(self.sections):
             if section["id"] == section_id:

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -675,23 +675,6 @@ class QuestionnaireSchema:
                     if repeating_block["id"] == block_id:
                         return block["id"]
 
-    def resolve_parent_block_index_for_source(self, parent_block_id: str) -> int:
-        if (
-            self.block_ids.index(parent_block_id)
-            or self.block_ids.index(parent_block_id) == 0
-        ):
-            return self.block_ids.index(parent_block_id)
-
-        if list_collector_id := self.get_list_collector_block_id_for_add_block(
-            parent_block_id
-        ):
-            return self.block_ids.index(list_collector_id)
-
-        list_collector_with_repeating_blocks_id = (
-            self.get_list_collector_block_id_for_repeating_blocks(parent_block_id)
-        )
-        return self.block_ids.index(list_collector_with_repeating_blocks_id)
-
     def get_section_index_for_section_id(self, section_id: str) -> int:
         for index, section in enumerate(self.sections):
             if section["id"] == section_id:

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -157,10 +157,10 @@ class QuestionnaireValidator(Validator):
                             < lists_with_context[list_identifier]["block_index"]
                         ):
                             self.add_error(
-                                error_messages.LIST_REFERENCED_BEFORE_ADDED.format(
-                                    list_name=list_identifier
-                                ),
-                                section_name=section["id"],
+                                error_messages.LIST_REFERENCED_BEFORE_ADDED.format(),
+                                list_id=list_identifier,
+                                section_id=section["id"],
+                                parent_block_id=parent_block["id"],
                             )
                     elif (
                         section_index
@@ -169,8 +169,7 @@ class QuestionnaireValidator(Validator):
                         # Section level "enabled" rule that can use list source,
                         # check: common_definitions.json#/section_enabled
                         self.add_error(
-                            error_messages.LIST_REFERENCED_BEFORE_ADDED.format(
-                                list_name=list_identifier
-                            ),
-                            section_name=section["id"],
+                            error_messages.LIST_REFERENCED_BEFORE_ADDED.format(),
+                            list_name=list_identifier,
+                            section_id=section["id"],
                         )

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -141,7 +141,7 @@ class QuestionnaireValidator(Validator):
             self.add_error(error_messages.PREVIEW_WITHOUT_INTRODUCTION_BLOCK)
 
     def validate_list_references(self):
-        referenced_lists = self.questionnaire_schema.referenced_lists
+        lists_with_context = self.questionnaire_schema.lists_with_context
 
         # We need to keep track of section index for: common_definitions.json#/section_enabled
         for section_index, section in enumerate(self.questionnaire_schema.sections):
@@ -156,7 +156,7 @@ class QuestionnaireValidator(Validator):
                         )
                         if (
                             parent_block_index
-                            < referenced_lists[list_identifier]["block_index"]
+                            < lists_with_context[list_identifier]["block_index"]
                         ):
                             self.add_error(
                                 error_messages.LIST_REFERENCED_BEFORE_ADDED.format(
@@ -166,7 +166,7 @@ class QuestionnaireValidator(Validator):
                             )
                     elif (
                         section_index
-                        < referenced_lists[list_identifier]["section_index"]
+                        < lists_with_context[list_identifier]["section_index"]
                     ):
                         # Section level "enabled" rule that can use list source,
                         # check: common_definitions.json#/section_enabled

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -143,12 +143,14 @@ class QuestionnaireValidator(Validator):
     def validate_list_references(self):
         referenced_lists = self.populated_referenced_lists()
 
+        # We need to keep track of section index for: common_definitions.json#/section_enabled
         for section_index, section in enumerate(self.questionnaire_schema.sections):
             identifier_references = get_object_containing_key(section, "source")
             for _, identifier_reference, parent_block in identifier_references:
                 if identifier_reference["source"] == "list":
                     list_identifier = identifier_reference["identifier"]
                     if parent_block:
+                        # Parent block might not always be top level "Block" so we need to resolve it below
                         parent_block_index = self.questionnaire_schema.resolve_parent_block_index_for_source(
                             parent_block["id"]
                         )
@@ -166,6 +168,8 @@ class QuestionnaireValidator(Validator):
                         section_index
                         < referenced_lists[list_identifier]["section_index"]
                     ):
+                        # Section level "enabled" rule that can use list source,
+                        # check: common_definitions.json#/section_enabled
                         self.add_error(
                             error_messages.LIST_REFERENCED_BEFORE_ADDED.format(
                                 list_name=list_identifier

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -160,7 +160,7 @@ class QuestionnaireValidator(Validator):
                                 error_messages.LIST_REFERENCED_BEFORE_ADDED.format(),
                                 list_id=list_identifier,
                                 section_id=section["id"],
-                                parent_block_id=parent_block["id"],
+                                block_id=parent_block["id"],
                             )
                     elif (
                         section_index

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -150,12 +150,10 @@ class QuestionnaireValidator(Validator):
                 if identifier_reference["source"] == "list":
                     list_identifier = identifier_reference["identifier"]
                     if parent_block:
-                        # Parent block might not always be top level "Block" so we need to resolve it below
-                        parent_block_index = self.questionnaire_schema.resolve_parent_block_index_for_source(
-                            parent_block["id"]
-                        )
                         if (
-                            parent_block_index
+                            self.questionnaire_schema.block_ids.index(
+                                parent_block["id"]
+                            )
                             < lists_with_context[list_identifier]["block_index"]
                         ):
                             self.add_error(

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -141,7 +141,7 @@ class QuestionnaireValidator(Validator):
             self.add_error(error_messages.PREVIEW_WITHOUT_INTRODUCTION_BLOCK)
 
     def validate_list_references(self):
-        referenced_lists = self.populated_referenced_lists()
+        referenced_lists = self.populate_referenced_lists()
 
         # We need to keep track of section index for: common_definitions.json#/section_enabled
         for section_index, section in enumerate(self.questionnaire_schema.sections):
@@ -177,7 +177,7 @@ class QuestionnaireValidator(Validator):
                             section_name=section["id"],
                         )
 
-    def populated_referenced_lists(self):
+    def populate_referenced_lists(self):
         referenced_lists = {}
         if supplementary_list := self.questionnaire_schema.supplementary_lists:
             for list_id in supplementary_list:

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -157,7 +157,7 @@ class QuestionnaireValidator(Validator):
                             < lists_with_context[list_identifier]["block_index"]
                         ):
                             self.add_error(
-                                error_messages.LIST_REFERENCED_BEFORE_ADDED.format(),
+                                error_messages.LIST_REFERENCED_BEFORE_CREATED.format(),
                                 list_id=list_identifier,
                                 section_id=section["id"],
                                 block_id=parent_block["id"],
@@ -169,7 +169,7 @@ class QuestionnaireValidator(Validator):
                         # Section level "enabled" rule that can use list source,
                         # check: common_definitions.json#/section_enabled
                         self.add_error(
-                            error_messages.LIST_REFERENCED_BEFORE_ADDED.format(),
+                            error_messages.LIST_REFERENCED_BEFORE_CREATED.format(),
                             list_name=list_identifier,
                             section_id=section["id"],
                         )

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -141,7 +141,7 @@ class QuestionnaireValidator(Validator):
             self.add_error(error_messages.PREVIEW_WITHOUT_INTRODUCTION_BLOCK)
 
     def validate_list_references(self):
-        referenced_lists = self.populate_referenced_lists()
+        referenced_lists = self.questionnaire_schema.referenced_lists
 
         # We need to keep track of section index for: common_definitions.json#/section_enabled
         for section_index, section in enumerate(self.questionnaire_schema.sections):
@@ -176,53 +176,3 @@ class QuestionnaireValidator(Validator):
                             ),
                             section_name=section["id"],
                         )
-
-    def populate_referenced_lists(self):
-        referenced_lists = {}
-        if supplementary_list := self.questionnaire_schema.supplementary_lists:
-            for list_id in supplementary_list:
-                referenced_lists[list_id] = {"section_index": 0, "block_index": 0}
-
-        if blocks := self.questionnaire_schema.get_blocks(type="ListCollector"):
-            for block in blocks:
-                list_id = block["for_list"]
-                if list_id not in referenced_lists:
-                    section_id = self.questionnaire_schema.get_section_id_for_block_id(
-                        block["id"]
-                    )
-                    section_index = (
-                        self.questionnaire_schema.get_section_index_for_section_id(
-                            section_id
-                        )
-                    )
-                    referenced_lists[list_id] = {
-                        "section_index": section_index,
-                        "block_index": self.questionnaire_schema.block_ids.index(
-                            block["id"]
-                        ),
-                    }
-        if blocks := self.questionnaire_schema.get_blocks(
-            type="PrimaryPersonListCollector"
-        ):
-            for block in blocks:
-                list_id = block["for_list"]
-                if list_id not in referenced_lists or (
-                    self.questionnaire_schema.block_ids.index(block["id"])
-                    < referenced_lists[list_id]["block_index"]
-                ):
-                    section_id = self.questionnaire_schema.get_section_id_for_block_id(
-                        block["id"]
-                    )
-                    section_index = (
-                        self.questionnaire_schema.get_section_index_for_section_id(
-                            section_id
-                        )
-                    )
-                    referenced_lists[list_id] = {
-                        "section_index": section_index,
-                        "block_index": self.questionnaire_schema.block_ids.index(
-                            block["id"]
-                        ),
-                    }
-
-        return referenced_lists

--- a/tests/schemas/invalid/test_invalid_list_as_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_list_as_source_reference.json
@@ -1,0 +1,389 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test Custom Page Titles",
+  "theme": "default",
+  "description": "A questionnaire to test list referenced as source before it has been created.",
+  "messages": {},
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Hub",
+    "options": {}
+  },
+  "sections": [
+    {
+      "title": "Individual Section",
+      "summary": {
+        "show_on_completion": true,
+        "page_title": "Summary"
+      },
+      "groups": [
+        {
+          "blocks": [
+            {
+              "content": {
+                "contents": [
+                  {
+                    "description": {
+                      "placeholders": [
+                        {
+                          "placeholder": "person_name",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": [
+                                  {
+                                    "source": "answers",
+                                    "identifier": "first-name"
+                                  },
+                                  {
+                                    "source": "answers",
+                                    "identifier": "last-name"
+                                  }
+                                ]
+                              },
+                              "transform": "concatenate_list"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "In this section, we are going to ask you questions about <strong>{person_name}</strong>."
+                    }
+                  },
+                  {
+                    "list": ["date of birth"],
+                    "title": "You will need to know personal details such as"
+                  }
+                ],
+                "title": {
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "first-name"
+                              },
+                              {
+                                "source": "answers",
+                                "identifier": "last-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ],
+                  "text": "{person_name}"
+                }
+              },
+              "page_title": "Individual interstitial",
+              "id": "individual-interstitial",
+              "type": "Interstitial",
+              "skip_conditions": {
+                "when": {
+                  "<": [
+                    {
+                      "source": "list",
+                      "identifier": "household",
+                      "selector": "count"
+                    },
+                    2
+                  ]
+                }
+              }
+            },
+            {
+              "id": "proxy",
+              "page_title": "Proxy question",
+              "question": {
+                "answers": [
+                  {
+                    "default": "No, I am answering on their behalf",
+                    "id": "proxy-answer",
+                    "mandatory": false,
+                    "options": [
+                      {
+                        "label": "Yes, I am",
+                        "value": "Yes, I am"
+                      },
+                      {
+                        "label": "No, I am answering on their behalf",
+                        "value": "No, I am answering on their behalf"
+                      }
+                    ],
+                    "type": "Radio"
+                  }
+                ],
+                "id": "proxy-question",
+                "title": {
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "first-name"
+                              },
+                              {
+                                "source": "answers",
+                                "identifier": "last-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ],
+                  "text": "Are you <strong>{person_name}?</strong>"
+                },
+                "type": "General"
+              },
+              "type": "Question"
+            },
+            {
+              "type": "Question",
+              "id": "date-of-birth",
+              "question": {
+                "id": "date-pipe-question",
+                "title": "What is your date of birth?",
+                "type": "General",
+                "answers": [
+                  {
+                    "id": "date-dob",
+                    "label": "For example 20 March 1990",
+                    "mandatory": false,
+                    "type": "Date"
+                  }
+                ]
+              }
+            }
+          ],
+          "id": "personal-details-group",
+          "title": "Personal Details"
+        }
+      ],
+      "id": "individual-section",
+      "repeat": {
+        "for_list": "household",
+        "title": {
+          "placeholders": [
+            {
+              "placeholder": "person_name",
+              "transforms": [
+                {
+                  "arguments": {
+                    "delimiter": " ",
+                    "list_to_concatenate": [
+                      {
+                        "source": "answers",
+                        "identifier": "first-name"
+                      },
+                      {
+                        "source": "answers",
+                        "identifier": "last-name"
+                      }
+                    ]
+                  },
+                  "transform": "concatenate_list"
+                }
+              ]
+            }
+          ],
+          "text": "{person_name}"
+        },
+        "page_title": "Person {list_item_position}"
+      }
+    },
+    {
+      "id": "section",
+      "title": "Household",
+      "summary": {
+        "show_on_completion": true,
+        "page_title": "Custom section summary page title",
+        "items": [
+          {
+            "add_link_text": "Add someone to this household",
+            "empty_list_text": "There are no householders",
+            "for_list": "household",
+            "title": "Household members",
+            "type": "List"
+          }
+        ]
+      },
+      "groups": [
+        {
+          "id": "group",
+          "title": "List Collector",
+          "blocks": [
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "page_title": "Custom page title",
+              "for_list": "household",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Does anyone else live at 1 Pleasant Lane?",
+                "answers": [
+                  {
+                    "id": "anyone-else",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-person",
+                "type": "ListAddQuestion",
+                "page_title": "Add person {list_item_position}",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-person",
+                "type": "ListEditQuestion",
+                "page_title": "Edit person {list_item_position}",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-person",
+                "type": "ListRemoveQuestion",
+                "page_title": "Remove person {list_item_position}",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this person?",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "People who live here",
+                "item_title": {
+                  "text": "{person_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "first-name"
+                              },
+                              {
+                                "source": "answers",
+                                "identifier": "last-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schemas/invalid/test_invalid_list_as_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_list_as_source_reference.json
@@ -113,7 +113,25 @@
                     2
                   ]
                 }
-              }
+              },
+              "routing_rules": [
+                {
+                  "section": "End",
+                  "when": {
+                    "<": [
+                      {
+                        "source": "list",
+                        "identifier": "household",
+                        "selector": "count"
+                      },
+                      1
+                    ]
+                  }
+                },
+                {
+                  "block": "proxy"
+                }
+              ]
             },
             {
               "id": "proxy",
@@ -220,10 +238,25 @@
           "text": "{person_name}"
         },
         "page_title": "Person {list_item_position}"
+      },
+      "enabled": {
+        "when": {
+          ">": [
+            {
+              "count": [
+                {
+                  "source": "list",
+                  "identifier": "household"
+                }
+              ]
+            },
+            0
+          ]
+        }
       }
     },
     {
-      "id": "section",
+      "id": "list-collector-section",
       "title": "Household",
       "summary": {
         "show_on_completion": true,

--- a/tests/schemas/invalid/test_invalid_list_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_list_source_reference.json
@@ -4,9 +4,9 @@
   "schema_version": "0.0.1",
   "data_version": "0.0.3",
   "survey_id": "0",
-  "title": "Test Custom Page Titles",
+  "title": "Test List Referenced Before Created",
   "theme": "default",
-  "description": "A questionnaire to test list referenced as source before it has been created.",
+  "description": "A questionnaire to test list referenced as source before it has been created",
   "messages": {},
   "metadata": [
     {

--- a/tests/schemas/invalid/test_invalid_list_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_list_source_reference.json
@@ -28,7 +28,7 @@
   },
   "sections": [
     {
-      "title": "Individual Section",
+      "title": "Individuals Section",
       "summary": {
         "show_on_completion": true,
         "page_title": "Summary"
@@ -322,7 +322,7 @@
           "title": "Personal Details"
         }
       ],
-      "id": "individual-section",
+      "id": "individuals-section",
       "repeat": {
         "for_list": "household",
         "title": {
@@ -370,7 +370,7 @@
       }
     },
     {
-      "id": "list-collector-section",
+      "id": "household-section",
       "title": "Household",
       "summary": {
         "show_on_completion": true,
@@ -387,7 +387,7 @@
       },
       "groups": [
         {
-          "id": "group",
+          "id": "list-collector-group",
           "title": "List Collector",
           "blocks": [
             {
@@ -523,6 +523,261 @@
                           "transform": "concatenate_list"
                         }
                       ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "utility-bills-section",
+      "title": "Utility bills",
+      "summary": {
+        "show_on_completion": true,
+        "items": [
+          {
+            "type": "List",
+            "for_list": "utility-bills",
+            "title": "Utility bills",
+            "item_anchor_answer_id": "utility-bill-name",
+            "item_label": "Utility bill",
+            "add_link_text": "Add another utility bill",
+            "empty_list_text": "No utility bills added"
+          }
+        ],
+        "show_non_item_answers": true
+      },
+      "groups": [
+        {
+          "id": "utility-bills-group",
+          "title": "Utility bills",
+          "blocks": [
+            {
+              "type": "Question",
+              "id": "dynamic-answer",
+              "skip_conditions": {
+                "when": {
+                  "==": [
+                    {
+                      "count": [
+                        {
+                          "source": "list",
+                          "identifier": "utility-bills"
+                        }
+                      ]
+                    },
+                    0
+                  ]
+                }
+              },
+              "question": {
+                "dynamic_answers": {
+                  "values": {
+                    "source": "list",
+                    "identifier": "utility-bills"
+                  },
+                  "answers": [
+                    {
+                      "label": {
+                        "text": "Monthly expenditure on {utility_bill} bills",
+                        "placeholders": [
+                          {
+                            "placeholder": "utility_bill",
+                            "value": {
+                              "source": "answers",
+                              "identifier": "utility-bill-name"
+                            }
+                          }
+                        ]
+                      },
+                      "id": "utility-bill-monthly-cost",
+                      "type": "Currency",
+                      "mandatory": true,
+                      "currency": "GBP",
+                      "decimal_places": 2
+                    }
+                  ]
+                },
+                "id": "dynamic-answer-question",
+                "title": "Monthly expenditure on utility bills",
+                "type": "General"
+              }
+            },
+            {
+              "type": "ListCollectorDrivingQuestion",
+              "id": "any-utility-bills",
+              "for_list": "utility-bills",
+              "question": {
+                "type": "General",
+                "id": "any-utility-bills-question",
+                "title": "Do you have any monthly expenditure on Utility bills?",
+                "answers": [
+                  {
+                    "type": "Radio",
+                    "id": "any-utility-bills-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock",
+                          "params": {
+                            "block_id": "add-utility-bill",
+                            "list_name": "utility-bills"
+                          }
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "routing_rules": [
+                {
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "any-utility-bills-answer"
+                      },
+                      "Yes"
+                    ]
+                  },
+                  "block": "any-other-utility-bills"
+                },
+                {
+                  "section": "End"
+                }
+              ]
+            },
+            {
+              "id": "any-other-utility-bills",
+              "type": "ListCollector",
+              "for_list": "utility-bills",
+              "question": {
+                "id": "any-other-utility-bills-question",
+                "type": "General",
+                "title": "Do you need to add any other Utility bills?",
+                "answers": [
+                  {
+                    "id": "any-other-utility-bills-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-utility-bill",
+                "type": "ListAddQuestion",
+                "question": {
+                  "id": "add-utility-bill-question",
+                  "type": "General",
+                  "title": "What bill do you need to add expenditure for?",
+                  "answers": [
+                    {
+                      "id": "utility-bill-name",
+                      "label": "Utility bill",
+                      "mandatory": true,
+                      "type": "Dropdown",
+                      "options": [
+                        {
+                          "label": "Electricity",
+                          "value": "Electricity"
+                        },
+                        {
+                          "label": "Water",
+                          "value": "Water"
+                        },
+                        {
+                          "label": "Gas",
+                          "value": "Gas"
+                        },
+                        {
+                          "label": "Internet",
+                          "value": "Internet"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-utility-bill",
+                "type": "ListEditQuestion",
+                "question": {
+                  "id": "edit-utility-bill-question",
+                  "type": "General",
+                  "title": "What is the name of the game?",
+                  "answers": [
+                    {
+                      "id": "utility-bill-name",
+                      "label": "Name of Utility bill",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-utility-bill",
+                "type": "ListRemoveQuestion",
+                "question": {
+                  "id": "remove-utility-bill-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this Utility bill?",
+                  "answers": [
+                    {
+                      "id": "remove-utility-bill-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "Utility bills",
+                "item_title": {
+                  "text": "{utility_bill}",
+                  "placeholders": [
+                    {
+                      "placeholder": "utility_bill",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "utility-bill-name"
+                      }
                     }
                   ]
                 }

--- a/tests/schemas/invalid/test_invalid_list_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_list_source_reference.json
@@ -202,6 +202,120 @@
                   }
                 ]
               }
+            },
+            {
+              "type": "Question",
+              "id": "favourite-drink",
+              "question": {
+                "answers": [
+                  {
+                    "id": "favourite-drink-answer",
+                    "label": "What is your favourite drink",
+                    "max_length": 20,
+                    "mandatory": false,
+                    "type": "TextField"
+                  }
+                ],
+                "id": "favourite-drink-question",
+                "title": "Title",
+                "type": "General"
+              }
+            },
+            {
+              "id": "list-status-2",
+              "question_variants": [
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "list-status-answer-2",
+                        "mandatory": false,
+                        "options": [
+                          {
+                            "label": "Tea",
+                            "value": "Tea"
+                          },
+                          {
+                            "label": "Coffee",
+                            "value": "Coffee"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "id": "list-status-question-2",
+                    "title": "What is your second favourite drink?",
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "identifier": "household",
+                        "source": "list",
+                        "selector": "first"
+                      },
+                      {
+                        "source": "location",
+                        "identifier": "list_item_id"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "list-status-answer-2",
+                        "mandatory": false,
+                        "options": [
+                          {
+                            "label": {
+                              "text": "{answer}",
+                              "placeholders": [
+                                {
+                                  "placeholder": "answer",
+                                  "value": {
+                                    "source": "answers",
+                                    "identifier": "favourite-drink-answer",
+                                    "list_item_selector": {
+                                      "source": "list",
+                                      "identifier": "household",
+                                      "selector": "first"
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            "value": "{answer}"
+                          },
+                          {
+                            "label": "Other",
+                            "value": "Other"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "id": "list-status-question-2",
+                    "title": "What is your second favourite drink?",
+                    "type": "General"
+                  },
+                  "when": {
+                    "!=": [
+                      {
+                        "identifier": "household",
+                        "source": "list",
+                        "selector": "first"
+                      },
+                      {
+                        "source": "location",
+                        "identifier": "list_item_id"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "type": "Question"
             }
           ],
           "id": "personal-details-group",

--- a/tests/schemas/invalid/test_invalid_list_source_reference_repeating_blocks.json
+++ b/tests/schemas/invalid/test_invalid_list_source_reference_repeating_blocks.json
@@ -1,0 +1,380 @@
+{
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "data_version": "0.0.3",
+  "survey_id": "0",
+  "title": "Test List Referenced Before Created (Repeating Blocks)",
+  "theme": "default",
+  "description": "A questionnaire to test list referenced as source in repeating blocks before it has been created",
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
+    },
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {
+      "summary": {
+        "collapsible": false
+      }
+    }
+  },
+  "sections": [
+    {
+      "id": "section-companies",
+      "title": "General insurance business",
+      "summary": {
+        "show_on_completion": false
+      },
+      "groups": [
+        {
+          "id": "group-companies",
+          "blocks": [
+            {
+              "id": "any-other-companies-or-branches",
+              "type": "ListCollector",
+              "for_list": "other-companies",
+              "question": {
+                "id": "any-other-companies-or-branches-question",
+                "type": "General",
+                "title": "Do you need to add any other UK companies or branches that undertake general insurance business?",
+                "answers": [
+                  {
+                    "id": "any-other-companies-or-branches-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-other-company",
+                "type": "ListAddQuestion",
+                "question": {
+                  "id": "add-question-other-companies",
+                  "type": "General",
+                  "title": "What is the name and registration number of the company?",
+                  "answers": [
+                    {
+                      "id": "company-or-branch-name-other",
+                      "label": "Name of UK company or branch (Mandatory)",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "repeating_blocks": [
+                {
+                  "id": "companies-repeating-block-1",
+                  "type": "ListRepeatingQuestion",
+                  "question": {
+                    "id": "companies-repeating-block-1-question",
+                    "type": "General",
+                    "title": {
+                      "text": "Give details about {company_name}",
+                      "placeholders": [
+                        {
+                          "placeholder": "company_name",
+                          "value": {
+                            "source": "list",
+                            "identifier": "companies",
+                            "selector": "first"
+                          }
+                        }
+                      ]
+                    },
+                    "answers": [
+                      {
+                        "id": "registration-number",
+                        "label": "Registration number (Mandatory)",
+                        "mandatory": true,
+                        "type": "Number",
+                        "maximum": {
+                          "value": 999,
+                          "exclusive": false
+                        },
+                        "decimal_places": 0
+                      },
+                      {
+                        "id": "registration-date",
+                        "label": "Date of Registration (Mandatory)",
+                        "mandatory": true,
+                        "type": "Date",
+                        "maximum": {
+                          "value": "now"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "companies-repeating-block-2",
+                  "type": "ListRepeatingQuestion",
+                  "question": {
+                    "id": "companies-repeating-block-2-question",
+                    "type": "General",
+                    "title": {
+                      "text": "Give details about how {company_name} has been trading over the past {date_difference}.",
+                      "placeholders": [
+                        {
+                          "placeholder": "company_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "company-or-branch-name-other"
+                          }
+                        },
+                        {
+                          "placeholder": "date_difference",
+                          "transforms": [
+                            {
+                              "transform": "calculate_date_difference",
+                              "arguments": {
+                                "first_date": {
+                                  "source": "answers",
+                                  "identifier": "registration-date"
+                                },
+                                "second_date": {
+                                  "value": "now"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "answers": [
+                      {
+                        "type": "Radio",
+                        "label": "Has this company been trading in the UK? (Mandatory)",
+                        "id": "authorised-trader-uk-radio",
+                        "mandatory": true,
+                        "options": [
+                          {
+                            "label": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "label": "No",
+                            "value": "No"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "Radio",
+                        "label": "Has this company been trading in the EU? (Not mandatory)",
+                        "id": "authorised-trader-eu-radio",
+                        "mandatory": false,
+                        "options": [
+                          {
+                            "label": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "label": "No",
+                            "value": "No"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "edit_block": {
+                "id": "edit-other-company",
+                "type": "ListEditQuestion",
+                "question": {
+                  "id": "edit-question-other-companies",
+                  "type": "General",
+                  "title": "What is the name and registration number of the company?",
+                  "answers": [
+                    {
+                      "id": "company-or-branch-name-other",
+                      "label": "Name of UK company or branch (Mandatory)",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-other-company",
+                "type": "ListRemoveQuestion",
+                "question": {
+                  "id": "remove-question-other-companies",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this company or UK branch?",
+                  "answers": [
+                    {
+                      "id": "remove-other-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "Companies or UK branches",
+                "item_title": {
+                  "text": "{company_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "company_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "company-or-branch-name"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "id": "companies-or-branches",
+              "type": "ListCollector",
+              "for_list": "companies",
+              "question": {
+                "id": "companies-or-branches-question",
+                "type": "General",
+                "title": "Do you need to add any other UK companies or branches that undertake general insurance business?",
+                "answers": [
+                  {
+                    "id": "companies-or-branches-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-company",
+                "type": "ListAddQuestion",
+                "question": {
+                  "id": "add-question-companies",
+                  "type": "General",
+                  "title": "What is the name and registration number of the company?",
+                  "answers": [
+                    {
+                      "id": "company-or-branch-name",
+                      "label": "Name of UK company or branch (Mandatory)",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-company",
+                "type": "ListEditQuestion",
+                "question": {
+                  "id": "edit-question-companies",
+                  "type": "General",
+                  "title": "What is the name and registration number of the company?",
+                  "answers": [
+                    {
+                      "id": "company-or-branch-name",
+                      "label": "Name of UK company or branch (Mandatory)",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-company",
+                "type": "ListRemoveQuestion",
+                "question": {
+                  "id": "remove-question-companies",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this company or UK branch?",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "Companies or UK branches",
+                "item_title": {
+                  "text": "{company_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "company_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "company-or-branch-name"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -413,55 +413,53 @@ def test_list_as_source_referenced_before_created():
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
     expected_errors = [
-        [
-            {
-                "list_id": "household",
-                "message": "List referenced as source before it has been created.",
-                "parent_block_id": "individual-interstitial",
-                "section_id": "individuals-section",
-            },
-            {
-                "list_id": "household",
-                "message": "List referenced as source before it has been created.",
-                "parent_block_id": "individual-interstitial",
-                "section_id": "individuals-section",
-            },
-            {
-                "list_id": "household",
-                "message": "List referenced as source before it has been created.",
-                "parent_block_id": "list-status-2",
-                "section_id": "individuals-section",
-            },
-            {
-                "list_id": "household",
-                "message": "List referenced as source before it has been created.",
-                "parent_block_id": "list-status-2",
-                "section_id": "individuals-section",
-            },
-            {
-                "list_id": "household",
-                "message": "List referenced as source before it has been created.",
-                "parent_block_id": "list-status-2",
-                "section_id": "individuals-section",
-            },
-            {
-                "list_name": "household",
-                "message": "List referenced as source before it has been created.",
-                "section_id": "individuals-section",
-            },
-            {
-                "list_id": "utility-bills",
-                "message": "List referenced as source before it has been created.",
-                "parent_block_id": "dynamic-answer",
-                "section_id": "utility-bills-section",
-            },
-            {
-                "list_id": "utility-bills",
-                "message": "List referenced as source before it has been created.",
-                "parent_block_id": "dynamic-answer",
-                "section_id": "utility-bills-section",
-            },
-        ]
+        {
+            "list_id": "household",
+            "message": "List referenced as source before it has been created.",
+            "parent_block_id": "individual-interstitial",
+            "section_id": "individuals-section",
+        },
+        {
+            "list_id": "household",
+            "message": "List referenced as source before it has been created.",
+            "parent_block_id": "individual-interstitial",
+            "section_id": "individuals-section",
+        },
+        {
+            "list_id": "household",
+            "message": "List referenced as source before it has been created.",
+            "parent_block_id": "list-status-2",
+            "section_id": "individuals-section",
+        },
+        {
+            "list_id": "household",
+            "message": "List referenced as source before it has been created.",
+            "parent_block_id": "list-status-2",
+            "section_id": "individuals-section",
+        },
+        {
+            "list_id": "household",
+            "message": "List referenced as source before it has been created.",
+            "parent_block_id": "list-status-2",
+            "section_id": "individuals-section",
+        },
+        {
+            "list_name": "household",
+            "message": "List referenced as source before it has been created.",
+            "section_id": "individuals-section",
+        },
+        {
+            "list_id": "utility-bills",
+            "message": "List referenced as source before it has been created.",
+            "parent_block_id": "dynamic-answer",
+            "section_id": "utility-bills-section",
+        },
+        {
+            "list_id": "utility-bills",
+            "message": "List referenced as source before it has been created.",
+            "parent_block_id": "dynamic-answer",
+            "section_id": "utility-bills-section",
+        },
     ]
 
     validator.validate()
@@ -476,14 +474,12 @@ def test_list_as_source_referenced_before_created_repeating_blocks():
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
     expected_errors = [
-        [
-            {
-                "list_id": "companies",
-                "message": "List referenced as source before it has been created.",
-                "parent_block_id": "any-other-companies-or-branches",
-                "section_id": "section-companies",
-            }
-        ]
+        {
+            "list_id": "companies",
+            "message": "List referenced as source before it has been created.",
+            "parent_block_id": "any-other-companies-or-branches",
+            "section_id": "section-companies",
+        }
     ]
 
     validator.validate()

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -415,49 +415,49 @@ def test_list_as_source_referenced_before_created():
     expected_errors = [
         {
             "list_id": "household",
-            "message": "List referenced as source before it has been created.",
-            "parent_block_id": "individual-interstitial",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "block_id": "individual-interstitial",
             "section_id": "individuals-section",
         },
         {
             "list_id": "household",
-            "message": "List referenced as source before it has been created.",
-            "parent_block_id": "individual-interstitial",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "block_id": "individual-interstitial",
             "section_id": "individuals-section",
         },
         {
             "list_id": "household",
-            "message": "List referenced as source before it has been created.",
-            "parent_block_id": "list-status-2",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "block_id": "list-status-2",
             "section_id": "individuals-section",
         },
         {
             "list_id": "household",
-            "message": "List referenced as source before it has been created.",
-            "parent_block_id": "list-status-2",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "block_id": "list-status-2",
             "section_id": "individuals-section",
         },
         {
             "list_id": "household",
-            "message": "List referenced as source before it has been created.",
-            "parent_block_id": "list-status-2",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "block_id": "list-status-2",
             "section_id": "individuals-section",
         },
         {
             "list_name": "household",
-            "message": "List referenced as source before it has been created.",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
             "section_id": "individuals-section",
         },
         {
             "list_id": "utility-bills",
-            "message": "List referenced as source before it has been created.",
-            "parent_block_id": "dynamic-answer",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "block_id": "dynamic-answer",
             "section_id": "utility-bills-section",
         },
         {
             "list_id": "utility-bills",
-            "message": "List referenced as source before it has been created.",
-            "parent_block_id": "dynamic-answer",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "block_id": "dynamic-answer",
             "section_id": "utility-bills-section",
         },
     ]
@@ -476,8 +476,8 @@ def test_list_as_source_referenced_before_created_repeating_blocks():
     expected_errors = [
         {
             "list_id": "companies",
-            "message": "List referenced as source before it has been created.",
-            "parent_block_id": "any-other-companies-or-branches",
+            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "block_id": "any-other-companies-or-branches",
             "section_id": "section-companies",
         }
     ]

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -417,32 +417,42 @@ def test_list_as_source_referenced_before_created():
         {
             "message": "List 'household' referenced as source before it has been "
             "created.",
-            "section_name": "individual-section",
+            "section_name": "individuals-section",
         },
         {
             "message": "List 'household' referenced as source before it has been "
             "created.",
-            "section_name": "individual-section",
+            "section_name": "individuals-section",
         },
         {
             "message": "List 'household' referenced as source before it has been "
             "created.",
-            "section_name": "individual-section",
+            "section_name": "individuals-section",
         },
         {
             "message": "List 'household' referenced as source before it has been "
             "created.",
-            "section_name": "individual-section",
+            "section_name": "individuals-section",
         },
         {
             "message": "List 'household' referenced as source before it has been "
             "created.",
-            "section_name": "individual-section",
+            "section_name": "individuals-section",
         },
         {
             "message": "List 'household' referenced as source before it has been "
             "created.",
-            "section_name": "individual-section",
+            "section_name": "individuals-section",
+        },
+        {
+            "message": "List 'utility-bills' referenced as source before it has been "
+            "created.",
+            "section_name": "utility-bills-section",
+        },
+        {
+            "message": "List 'utility-bills' referenced as source before it has been "
+            "created.",
+            "section_name": "utility-bills-section",
         },
     ]
 

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -406,3 +406,21 @@ def test_invalid_calculated_or_grand_calculated_summary_id_in_value_source():
     validator.validate()
 
     assert validator.errors == expected_errors
+
+
+def test_list_as_source_referenced_before_created():
+    """Asserts `invalid` when a value source references an invalid calculated or grand calculated summary id"""
+    filename = "schemas/invalid/test_invalid_list_as_source_reference.json"
+    validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
+
+    expected_errors = [
+        {
+            "message": "List 'household' referenced as source before it has been "
+            "created.",
+            "section_name": "individual-section",
+        }
+    ]
+
+    validator.validate()
+
+    assert validator.errors == expected_errors

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -415,48 +415,48 @@ def test_list_as_source_referenced_before_created():
     expected_errors = [
         {
             "list_id": "household",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "block_id": "individual-interstitial",
             "section_id": "individuals-section",
         },
         {
             "list_id": "household",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "block_id": "individual-interstitial",
             "section_id": "individuals-section",
         },
         {
             "list_id": "household",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "block_id": "list-status-2",
             "section_id": "individuals-section",
         },
         {
             "list_id": "household",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "block_id": "list-status-2",
             "section_id": "individuals-section",
         },
         {
             "list_id": "household",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "block_id": "list-status-2",
             "section_id": "individuals-section",
         },
         {
             "list_name": "household",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "section_id": "individuals-section",
         },
         {
             "list_id": "utility-bills",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "block_id": "dynamic-answer",
             "section_id": "utility-bills-section",
         },
         {
             "list_id": "utility-bills",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "block_id": "dynamic-answer",
             "section_id": "utility-bills-section",
         },
@@ -476,7 +476,7 @@ def test_list_as_source_referenced_before_created_repeating_blocks():
     expected_errors = [
         {
             "list_id": "companies",
-            "message": error_messages.LIST_REFERENCED_BEFORE_ADDED,
+            "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
             "block_id": "any-other-companies-or-branches",
             "section_id": "section-companies",
         }

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -409,7 +409,6 @@ def test_invalid_calculated_or_grand_calculated_summary_id_in_value_source():
 
 
 def test_list_as_source_referenced_before_created():
-    """Asserts `invalid` when a value source references an invalid calculated or grand calculated summary id"""
     filename = "schemas/invalid/test_invalid_list_source_reference.json"
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
@@ -454,6 +453,25 @@ def test_list_as_source_referenced_before_created():
             "created.",
             "section_name": "utility-bills-section",
         },
+    ]
+
+    validator.validate()
+
+    assert validator.errors == expected_errors
+
+
+def test_list_as_source_referenced_before_created_repeating_blocks():
+    filename = (
+        "schemas/invalid/test_invalid_list_source_reference_repeating_blocks.json"
+    )
+    validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
+
+    expected_errors = [
+        {
+            "message": "List 'companies' referenced as source before it has been "
+            "created.",
+            "section_name": "section-companies",
+        }
     ]
 
     validator.validate()

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -418,7 +418,17 @@ def test_list_as_source_referenced_before_created():
             "message": "List 'household' referenced as source before it has been "
             "created.",
             "section_name": "individual-section",
-        }
+        },
+        {
+            "message": "List 'household' referenced as source before it has been "
+            "created.",
+            "section_name": "individual-section",
+        },
+        {
+            "message": "List 'household' referenced as source before it has been "
+            "created.",
+            "section_name": "individual-section",
+        },
     ]
 
     validator.validate()

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -410,10 +410,25 @@ def test_invalid_calculated_or_grand_calculated_summary_id_in_value_source():
 
 def test_list_as_source_referenced_before_created():
     """Asserts `invalid` when a value source references an invalid calculated or grand calculated summary id"""
-    filename = "schemas/invalid/test_invalid_list_as_source_reference.json"
+    filename = "schemas/invalid/test_invalid_list_source_reference.json"
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
     expected_errors = [
+        {
+            "message": "List 'household' referenced as source before it has been "
+            "created.",
+            "section_name": "individual-section",
+        },
+        {
+            "message": "List 'household' referenced as source before it has been "
+            "created.",
+            "section_name": "individual-section",
+        },
+        {
+            "message": "List 'household' referenced as source before it has been "
+            "created.",
+            "section_name": "individual-section",
+        },
         {
             "message": "List 'household' referenced as source before it has been "
             "created.",

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -413,46 +413,55 @@ def test_list_as_source_referenced_before_created():
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
     expected_errors = [
-        {
-            "message": "List 'household' referenced as source before it has been "
-            "created.",
-            "section_name": "individuals-section",
-        },
-        {
-            "message": "List 'household' referenced as source before it has been "
-            "created.",
-            "section_name": "individuals-section",
-        },
-        {
-            "message": "List 'household' referenced as source before it has been "
-            "created.",
-            "section_name": "individuals-section",
-        },
-        {
-            "message": "List 'household' referenced as source before it has been "
-            "created.",
-            "section_name": "individuals-section",
-        },
-        {
-            "message": "List 'household' referenced as source before it has been "
-            "created.",
-            "section_name": "individuals-section",
-        },
-        {
-            "message": "List 'household' referenced as source before it has been "
-            "created.",
-            "section_name": "individuals-section",
-        },
-        {
-            "message": "List 'utility-bills' referenced as source before it has been "
-            "created.",
-            "section_name": "utility-bills-section",
-        },
-        {
-            "message": "List 'utility-bills' referenced as source before it has been "
-            "created.",
-            "section_name": "utility-bills-section",
-        },
+        [
+            {
+                "list_id": "household",
+                "message": "List referenced as source before it has been created.",
+                "parent_block_id": "individual-interstitial",
+                "section_id": "individuals-section",
+            },
+            {
+                "list_id": "household",
+                "message": "List referenced as source before it has been created.",
+                "parent_block_id": "individual-interstitial",
+                "section_id": "individuals-section",
+            },
+            {
+                "list_id": "household",
+                "message": "List referenced as source before it has been created.",
+                "parent_block_id": "list-status-2",
+                "section_id": "individuals-section",
+            },
+            {
+                "list_id": "household",
+                "message": "List referenced as source before it has been created.",
+                "parent_block_id": "list-status-2",
+                "section_id": "individuals-section",
+            },
+            {
+                "list_id": "household",
+                "message": "List referenced as source before it has been created.",
+                "parent_block_id": "list-status-2",
+                "section_id": "individuals-section",
+            },
+            {
+                "list_name": "household",
+                "message": "List referenced as source before it has been created.",
+                "section_id": "individuals-section",
+            },
+            {
+                "list_id": "utility-bills",
+                "message": "List referenced as source before it has been created.",
+                "parent_block_id": "dynamic-answer",
+                "section_id": "utility-bills-section",
+            },
+            {
+                "list_id": "utility-bills",
+                "message": "List referenced as source before it has been created.",
+                "parent_block_id": "dynamic-answer",
+                "section_id": "utility-bills-section",
+            },
+        ]
     ]
 
     validator.validate()
@@ -467,11 +476,14 @@ def test_list_as_source_referenced_before_created_repeating_blocks():
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
     expected_errors = [
-        {
-            "message": "List 'companies' referenced as source before it has been "
-            "created.",
-            "section_name": "section-companies",
-        }
+        [
+            {
+                "list_id": "companies",
+                "message": "List referenced as source before it has been created.",
+                "parent_block_id": "any-other-companies-or-branches",
+                "section_id": "section-companies",
+            }
+        ]
     ]
 
     validator.validate()


### PR DESCRIPTION
### What is the context of this PR?
Adds validation of sources referencing lists, no longer list source for a given list can be referenced in a section that precedes the section in which the list collector itself for that list is set.

### How to review
New invalid schema added and new unit test that checks the error message.

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
