### PR TITLE
Add answer source reference order validation

### DIFF
--- a/app/error_messages.py
+++ b/app/error_messages.py
@@ -40,6 +40,6 @@ VARIANTS_HAVE_MULTIPLE_QUESTION_TYPES = (
     "Variants have more than one question type for block."
 )
 PREVIEW_WITHOUT_INTRODUCTION_BLOCK = "No introduction block found. Introduction block is mandatory when using the preview questions feature."
-ANSWER_REFERENCED_BEFORE_ADDED = (
+ANSWER_REFERENCED_BEFORE_EXISTS = (
     "Answer '{answer_id}' referenced as source before it has been added."
 )

--- a/app/error_messages.py
+++ b/app/error_messages.py
@@ -40,3 +40,6 @@ VARIANTS_HAVE_MULTIPLE_QUESTION_TYPES = (
     "Variants have more than one question type for block."
 )
 PREVIEW_WITHOUT_INTRODUCTION_BLOCK = "No introduction block found. Introduction block is mandatory when using the preview questions feature."
+ANSWER_REFERENCED_BEFORE_ADDED = (
+    "Answer '{answer_id}' referenced as source before it has been added."
+)

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -621,7 +621,7 @@ class QuestionnaireSchema:
                     return self.sections_by_id[section_id]
 
     def get_parent_list_collector_for_add_block(self, block_id) -> dict | None:
-        for _, blocks in self.blocks_by_section_id.items():
+        for blocks in self.blocks_by_section_id.values():
             for block in blocks:
                 if (
                     block["type"] == "ListCollector"
@@ -630,7 +630,7 @@ class QuestionnaireSchema:
                     return block["id"]
 
     def get_parent_list_collector_for_repeating_block(self, block_id) -> dict | None:
-        for _, blocks in self.blocks_by_section_id.items():
+        for blocks in self.blocks_by_section_id.values():
             for block in blocks:
                 if block["type"] in [
                     "ListCollector",
@@ -639,6 +639,7 @@ class QuestionnaireSchema:
                     for repeating_block in block["repeating_blocks"]:
                         if repeating_block["id"] == block_id:
                             return block["id"]
+        return None
 
     def is_block_in_repeating_section(self, block_id: str) -> bool:
         parent_section = self.get_parent_section_for_block(block_id)

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -585,7 +585,7 @@ class QuestionnaireSchema:
                     return self.sections_by_id[section_id]
 
     def get_parent_list_collector_for_add_block(self, block_id) -> dict | None:
-        for section_id, blocks in self.blocks_by_section_id.items():
+        for _, blocks in self.blocks_by_section_id.items():
             for block in blocks:
                 if (
                     block["type"] == "ListCollector"
@@ -594,7 +594,7 @@ class QuestionnaireSchema:
                     return block["id"]
 
     def get_parent_list_collector_for_repeating_block(self, block_id) -> dict | None:
-        for section_id, blocks in self.blocks_by_section_id.items():
+        for _, blocks in self.blocks_by_section_id.items():
             for block in blocks:
                 if block["type"] in [
                     "ListCollector",

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -587,13 +587,19 @@ class QuestionnaireSchema:
     def get_parent_list_collector_for_add_block(self, block_id) -> dict | None:
         for section_id, blocks in self.blocks_by_section_id.items():
             for block in blocks:
-                if block["type"] == "ListCollector" and block["add_block"]["id"] == block_id:
+                if (
+                    block["type"] == "ListCollector"
+                    and block["add_block"]["id"] == block_id
+                ):
                     return block["id"]
 
     def get_parent_list_collector_for_repeating_block(self, block_id) -> dict | None:
         for section_id, blocks in self.blocks_by_section_id.items():
             for block in blocks:
-                if block["type"] in ["ListCollector", "ListCollectorContent"] and block.get("repeating_blocks"):
+                if block["type"] in [
+                    "ListCollector",
+                    "ListCollectorContent",
+                ] and block.get("repeating_blocks"):
                     for repeating_block in block["repeating_blocks"]:
                         if repeating_block["id"] == block_id:
                             return block["id"]

--- a/app/validators/questionnaire_schema.py
+++ b/app/validators/questionnaire_schema.py
@@ -584,6 +584,20 @@ class QuestionnaireSchema:
                 if block_id == block["id"]:
                     return self.sections_by_id[section_id]
 
+    def get_parent_list_collector_for_add_block(self, block_id) -> dict | None:
+        for section_id, blocks in self.blocks_by_section_id.items():
+            for block in blocks:
+                if block["type"] == "ListCollector" and block["add_block"]["id"] == block_id:
+                    return block["id"]
+
+    def get_parent_list_collector_for_repeating_block(self, block_id) -> dict | None:
+        for section_id, blocks in self.blocks_by_section_id.items():
+            for block in blocks:
+                if block["type"] in ["ListCollector", "ListCollectorContent"] and block.get("repeating_blocks"):
+                    for repeating_block in block["repeating_blocks"]:
+                        if repeating_block["id"] == block_id:
+                            return block["id"]
+
     def is_block_in_repeating_section(self, block_id: str) -> bool:
         parent_section = self.get_parent_section_for_block(block_id)
         return parent_section and self.is_repeating_section(parent_section["id"])
@@ -617,3 +631,8 @@ class QuestionnaireSchema:
     def get_section_id_for_block_id(self, block_id: str) -> str | None:
         if block := self.get_block(block_id):
             return self.get_section_id_for_block(block)
+
+    def get_section_index_for_section_id(self, section_id: str) -> int:
+        for index, section in enumerate(self.sections):
+            if section["id"] == section_id:
+                return index

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -203,7 +203,7 @@ class QuestionnaireValidator(Validator):
                             error_messages.ANSWER_REFERENCED_BEFORE_EXISTS.format(
                                 answer_id=identifier_reference["identifier"]
                             ),
-                            group_d=group["id"],
+                            group_id=group["id"],
                         )
 
     def validate_answer_source_section(self, section, section_index):

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -195,14 +195,14 @@ class QuestionnaireValidator(Validator):
                             error_messages.ANSWER_REFERENCED_BEFORE_EXISTS.format(
                                 answer_id=identifier_reference["identifier"]
                             ),
-                            block=parent_block_id,
+                            block_id=parent_block_id,
                         )
                     else:
                         self.add_error(
                             error_messages.ANSWER_REFERENCED_BEFORE_EXISTS.format(
                                 answer_id=identifier_reference["identifier"]
                             ),
-                            group=group["id"],
+                            group_d=group["id"],
                         )
 
     def validate_answer_source_section(self, section, section_index):
@@ -233,7 +233,7 @@ class QuestionnaireValidator(Validator):
                         error_messages.ANSWER_REFERENCED_BEFORE_EXISTS.format(
                             answer_id=identifier_reference["identifier"]
                         ),
-                        section=section["id"],
+                        section_id=section["id"],
                     )
 
     def resolve_source_block_id(self, source_block):

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -192,14 +192,14 @@ class QuestionnaireValidator(Validator):
                 if source_block_index > parent_block_index:
                     if parent_block_id:
                         self.add_error(
-                            error_messages.ANSWER_REFERENCED_BEFORE_ADDED.format(
+                            error_messages.ANSWER_REFERENCED_BEFORE_EXISTS.format(
                                 answer_id=identifier_reference["identifier"]
                             ),
                             block=parent_block_id,
                         )
                     else:
                         self.add_error(
-                            error_messages.ANSWER_REFERENCED_BEFORE_ADDED.format(
+                            error_messages.ANSWER_REFERENCED_BEFORE_EXISTS.format(
                                 answer_id=identifier_reference["identifier"]
                             ),
                             group=group["id"],
@@ -230,7 +230,7 @@ class QuestionnaireValidator(Validator):
                 )
                 if section_index < source_block_section_index:
                     self.add_error(
-                        error_messages.ANSWER_REFERENCED_BEFORE_ADDED.format(
+                        error_messages.ANSWER_REFERENCED_BEFORE_EXISTS.format(
                             answer_id=identifier_reference["identifier"]
                         ),
                         section=section["id"],

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -141,7 +141,7 @@ class QuestionnaireValidator(Validator):
         )
         if not has_introduction_blocks:
             self.add_error(error_messages.PREVIEW_WITHOUT_INTRODUCTION_BLOCK)
- 
+
     def validate_answer_references(self):
 
         # Handling blocks in group

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -154,25 +154,21 @@ class QuestionnaireValidator(Validator):
                     source_block = self.questionnaire_schema.get_block_by_answer_id(
                         identifier_reference["identifier"]
                     )
+                    # Handling non-existing blocks used as source
                     if not source_block:
                         self.add_error(
                             ValueSourceValidator.ANSWER_SOURCE_REFERENCE_INVALID,
                             identifier=identifier_reference["identifier"],
                         )
                         return False
-                    if "blocks" in path:
-                        # Getting the global index of the current block parent block id
-                        in_group_parent_block_index = int(
-                            re.search(r"\d+", path).group()
-                        )
-                        parent_block_id = group["blocks"][in_group_parent_block_index][
-                            "id"
-                        ]
+                    # Handling block level answer sources (skipping group level)
+                    if parent_block and "blocks" in path:
+                        parent_block_id = parent_block["id"]
                         parent_block_index = self.questionnaire_schema.block_ids.index(
                             parent_block_id
                         )
                     else:
-                        # Handling of group level skip conditions
+                        # Handling group level skip conditions
                         first_block_id_in_group = group["blocks"][0]["id"]
                         parent_block_index = self.questionnaire_schema.block_ids.index(
                             first_block_id_in_group
@@ -190,7 +186,7 @@ class QuestionnaireValidator(Validator):
                             ),
                             group_name=group["id"],
                         )
-        # Handling of "enabled" rule on section level
+        # Handling section level "enabled" rule
         for section_index, section in enumerate(self.questionnaire_schema.sections):
             identifier_references = get_object_containing_key(section, "source")
             for path, identifier_reference, parent_block in identifier_references:

--- a/app/validators/questionnaire_validator.py
+++ b/app/validators/questionnaire_validator.py
@@ -154,6 +154,8 @@ class QuestionnaireValidator(Validator):
     def validate_answer_source_group(self, group):
         identifier_references = get_object_containing_key(group, "source")
         for path, identifier_reference, parent_block in identifier_references:
+            # set up default parent_block_id for later check (group or block level)
+            parent_block_id = None
             if (
                 "source" in identifier_reference
                 and identifier_reference["source"] == "answers"
@@ -188,12 +190,20 @@ class QuestionnaireValidator(Validator):
                     source_block_id
                 )
                 if source_block_index > parent_block_index:
-                    self.add_error(
-                        error_messages.ANSWER_REFERENCED_BEFORE_ADDED.format(
-                            answer_id=identifier_reference["identifier"]
-                        ),
-                        group_name=group["id"],
-                    )
+                    if parent_block_id:
+                        self.add_error(
+                            error_messages.ANSWER_REFERENCED_BEFORE_ADDED.format(
+                                answer_id=identifier_reference["identifier"]
+                            ),
+                            block=parent_block_id,
+                        )
+                    else:
+                        self.add_error(
+                            error_messages.ANSWER_REFERENCED_BEFORE_ADDED.format(
+                                answer_id=identifier_reference["identifier"]
+                            ),
+                            group=group["id"],
+                        )
 
     def validate_answer_source_section(self, section, section_index):
         identifier_references = get_object_containing_key(section, "source")
@@ -223,7 +233,7 @@ class QuestionnaireValidator(Validator):
                         error_messages.ANSWER_REFERENCED_BEFORE_ADDED.format(
                             answer_id=identifier_reference["identifier"]
                         ),
-                        section_name=section["id"],
+                        section=section["id"],
                     )
 
     def resolve_source_block_id(self, source_block):

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -1,0 +1,140 @@
+{
+    "mime_type": "application/json/ons/eq",
+    "language": "en",
+    "schema_version": "0.0.1",
+    "survey_id": "139",
+    "theme": "default",
+    "title": "Confirmation Question Test",
+    "data_version": "0.0.3",
+    "description": "A questionnaire to test answers referenced as source before it has been added.",
+    "navigation": {
+        "visible": true
+    },
+    "metadata": [
+        {
+            "name": "user_id",
+            "type": "string"
+        },
+        {
+            "name": "period_id",
+            "type": "string"
+        },
+        {
+            "name": "ru_name",
+            "type": "string"
+        },
+        {
+            "name": "trad_as",
+            "type": "string",
+            "optional": true
+        }
+    ],
+    "questionnaire_flow": {
+        "type": "Linear",
+        "options": {
+            "summary": {
+                "collapsible": false
+            }
+        }
+    },
+    "sections": [
+        {
+            "id": "confirmation-section",
+            "title": "Questions",
+            "groups": [
+                {
+                    "id": "confirmation-block",
+                    "title": "Confirmation Question Group",
+                    "blocks": [
+                        {
+                            "id": "number-of-employees-split-block",
+                            "type": "Question",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "number-of-employees-more-30-hours",
+                                        "label": "Number of employees working more than 30 hours per week",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "maximum": {
+                                            "value": 1000
+                                            }
+                                        }
+
+                                ],
+                                "id": "number-of-employees-split-question",
+                                "title": {
+                                    "text": "Of the <strong>{number_of_employees_total}</strong> total employees employed, how many male and female employees worked the following hours?",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "number_of_employees_total",
+                                            "value": {
+                                                "source": "answers",
+                                                "identifier": "number-of-employees-total"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "type": "General"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "employees-section",
+            "title": "Questions",
+            "groups": [
+                {
+                    "id": "employees-block",
+                    "title": "Employees Question Group",
+                    "blocks": [
+                        {
+                            "id": "number-of-employees-total-block",
+                            "question": {
+                                "answers": [
+                                    {
+                                        "id": "number-of-employees-total",
+                                        "label": "Total number of employees",
+                                        "mandatory": false,
+                                        "type": "Number",
+                                        "default": 0
+                                    }
+                                ],
+                                "id": "number-of-employees-total-question",
+                                "title": {
+                                    "text": "How many employees work at {company_name}?",
+                                    "placeholders": [
+                                        {
+                                            "placeholder": "company_name",
+                                            "transforms": [
+                                                {
+                                                    "transform": "first_non_empty_item",
+                                                    "arguments": {
+                                                        "items": [
+                                                            {
+                                                                "source": "metadata",
+                                                                "identifier": "trad_as"
+                                                            },
+                                                            {
+                                                                "source": "metadata",
+                                                                "identifier": "ru_name"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "type": "General"
+                            },
+                            "type": "Question"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -1063,6 +1063,313 @@
           ]
         }
       ]
+    },
+    {
+      "id": "companies-section",
+      "title": "General insurance business",
+      "summary": {
+        "show_on_completion": true,
+        "items": [
+          {
+            "type": "List",
+            "for_list": "companies",
+            "title": "Companies or UK branches",
+            "item_anchor_answer_id": "company-or-branch-name",
+            "item_label": "Name of UK company or branch",
+            "add_link_text": "Add another UK company or branch",
+            "empty_list_text": "No UK company or branch added"
+          }
+        ],
+        "show_non_item_answers": true
+      },
+      "groups": [
+        {
+          "id": "group-companies",
+          "blocks": [
+            {
+              "id": "any-other-companies-or-branches",
+              "type": "ListCollector",
+              "for_list": "companies",
+              "question": {
+                "id": "any-other-companies-or-branches-question",
+                "type": "General",
+                "title": "Do you need to add any other UK companies or branches that undertake general insurance business?",
+                "answers": [
+                  {
+                    "id": "any-other-companies-or-branches-answer",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-company",
+                "type": "ListAddQuestion",
+                "question": {
+                  "id": "add-question-companies",
+                  "type": "General",
+                  "title": "What is the name and registration number of the company?",
+                  "answers": [
+                    {
+                      "id": "company-or-branch-name",
+                      "label": "Name of UK company or branch (Mandatory)",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "repeating_blocks": [
+                {
+                  "id": "companies-repeating-block-1",
+                  "type": "ListRepeatingQuestion",
+                  "question": {
+                    "id": "companies-repeating-block-1-question",
+                    "type": "General",
+                    "title": {
+                      "text": "You answered {any_other} about adding companies. Give details about {company_name}",
+                      "placeholders": [
+                        {
+                          "placeholder": "any_other",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "any-companies-or-branches-answer"
+                          }
+                        },
+                        {
+                          "placeholder": "company_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "company-or-branch-name"
+                          }
+                        }
+                      ]
+                    },
+                    "answers": [
+                      {
+                        "id": "registration-number",
+                        "label": "Registration number (Mandatory)",
+                        "mandatory": true,
+                        "type": "Number",
+                        "maximum": {
+                          "value": 999,
+                          "exclusive": false
+                        },
+                        "decimal_places": 0
+                      },
+                      {
+                        "id": "registration-date",
+                        "label": "Date of Registration (Mandatory)",
+                        "mandatory": true,
+                        "type": "Date",
+                        "maximum": {
+                          "value": "now"
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "companies-repeating-block-2",
+                  "type": "ListRepeatingQuestion",
+                  "question": {
+                    "id": "companies-repeating-block-2-question",
+                    "type": "General",
+                    "title": {
+                      "text": "Give details about how {company_name} has been trading over the past {date_difference}.",
+                      "placeholders": [
+                        {
+                          "placeholder": "company_name",
+                          "value": {
+                            "source": "answers",
+                            "identifier": "company-or-branch-name"
+                          }
+                        },
+                        {
+                          "placeholder": "date_difference",
+                          "transforms": [
+                            {
+                              "transform": "calculate_date_difference",
+                              "arguments": {
+                                "first_date": {
+                                  "source": "answers",
+                                  "identifier": "registration-date"
+                                },
+                                "second_date": {
+                                  "value": "now"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "answers": [
+                      {
+                        "type": "Radio",
+                        "label": "Has this company been trading in the UK? (Mandatory)",
+                        "id": "authorised-trader-uk-radio",
+                        "mandatory": true,
+                        "options": [
+                          {
+                            "label": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "label": "No",
+                            "value": "No"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "Radio",
+                        "label": "Has this company been trading in the EU? (Not mandatory)",
+                        "id": "authorised-trader-eu-radio",
+                        "mandatory": false,
+                        "options": [
+                          {
+                            "label": "Yes",
+                            "value": "Yes"
+                          },
+                          {
+                            "label": "No",
+                            "value": "No"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "edit_block": {
+                "id": "edit-company",
+                "type": "ListEditQuestion",
+                "question": {
+                  "id": "edit-question-companies",
+                  "type": "General",
+                  "title": "What is the name and registration number of the company?",
+                  "answers": [
+                    {
+                      "id": "company-or-branch-name",
+                      "label": "Name of UK company or branch (Mandatory)",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-company",
+                "type": "ListRemoveQuestion",
+                "question": {
+                  "id": "remove-question-companies",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this company or UK branch?",
+                  "answers": [
+                    {
+                      "id": "remove-company-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "Companies or UK branches",
+                "item_title": {
+                  "text": "{company_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "company_name",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "company-or-branch-name"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "ListCollectorDrivingQuestion",
+              "id": "any-companies-or-branches",
+              "for_list": "companies",
+              "question": {
+                "type": "General",
+                "id": "any-companies-or-branches-question",
+                "title": "Do any companies or branches within your United Kingdom group undertake general insurance business?",
+                "answers": [
+                  {
+                    "type": "Radio",
+                    "id": "any-companies-or-branches-answer",
+                    "mandatory": true,
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock",
+                          "params": {
+                            "block_id": "add-company",
+                            "list_name": "companies"
+                          }
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "routing_rules": [
+                {
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "any-companies-or-branches-answer"
+                      },
+                      "Yes"
+                    ]
+                  },
+                  "block": "any-other-companies-or-branches"
+                },
+                {
+                  "section": "End"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -265,162 +265,70 @@
             },
             {
               "id": "confirm-dob",
-              "question_variants": [
-                {
-                  "question": {
-                    "answers": [
+              "question": {
+                "answers": [
+                  {
+                    "id": "confirm-date-of-birth-answer",
+                    "mandatory": true,
+                    "options": [
                       {
-                        "id": "confirm-date-of-birth-answer",
-                        "mandatory": true,
-                        "options": [
-                          {
-                            "label": "Yes, that is my age",
-                            "value": "Yes, that is my age"
-                          },
-                          {
-                            "label": "No, I need to change my date of birth",
-                            "value": "No, I need to change my date of birth"
-                          }
-                        ],
-                        "type": "Radio"
+                        "label": "Yes, it is my age",
+                        "value": "Yes, it is my age"
+                      },
+                      {
+                        "label": "No, I need to change my date of birth",
+                        "value": "No, I need to change my date of birth"
                       }
                     ],
-                    "id": "confirm-date-of-birth",
-                    "title": {
-                      "placeholders": [
-                        {
-                          "placeholder": "age",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "first_date": {
-                                  "identifier": "date-of-birth-answer",
-                                  "source": "answers"
-                                },
-                                "second_date": {
-                                  "value": "now"
-                                }
-                              },
-                              "transform": "calculate_date_difference"
-                            }
-                          ]
-                        }
-                      ],
-                      "text": "You are {age} old. Is this correct?"
-                    },
-                    "type": "General"
-                  },
-                  "when": {
-                    "==": [
-                      {
-                        "source": "answers",
-                        "identifier": "proxy-answer"
-                      },
-                      "No, I’m answering for myself"
-                    ]
+                    "type": "Radio"
                   }
-                },
-                {
-                  "question": {
-                    "answers": [
-                      {
-                        "id": "confirm-date-of-birth-answer",
-                        "mandatory": true,
-                        "options": [
-                          {
-                            "label": {
-                              "placeholders": [
-                                {
-                                  "placeholder": "person_name",
-                                  "transforms": [
-                                    {
-                                      "arguments": {
-                                        "delimiter": " ",
-                                        "list_to_concatenate": [
-                                          {
-                                            "source": "answers",
-                                            "identifier": "first-name"
-                                          },
-                                          {
-                                            "source": "answers",
-                                            "identifier": "last-name"
-                                          }
-                                        ]
-                                      },
-                                      "transform": "concatenate_list"
-                                    }
-                                  ]
-                                }
-                              ],
-                              "text": "Yes, {person_name} is that age"
+                ],
+                "id": "confirm-date-of-birth",
+                "title": {
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "first-name"
+                              },
+                              {
+                                "source": "answers",
+                                "identifier": "last-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    },
+                    {
+                      "placeholder": "age",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "first_date": {
+                              "identifier": "date-of-birth-answer",
+                              "source": "answers"
                             },
-                            "value": "Yes, {person_name} is that age"
+                            "second_date": {
+                              "value": "now"
+                            }
                           },
-                          {
-                            "label": "No, I need to change their date of birth",
-                            "value": "No, I need to change their date of birth"
-                          }
-                        ],
-                        "type": "Radio"
-                      }
-                    ],
-                    "id": "confirm-date-of-birth",
-                    "title": {
-                      "placeholders": [
-                        {
-                          "placeholder": "person_name",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "delimiter": " ",
-                                "list_to_concatenate": [
-                                  {
-                                    "source": "answers",
-                                    "identifier": "first-name"
-                                  },
-                                  {
-                                    "source": "answers",
-                                    "identifier": "last-name"
-                                  }
-                                ]
-                              },
-                              "transform": "concatenate_list"
-                            }
-                          ]
-                        },
-                        {
-                          "placeholder": "age",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "first_date": {
-                                  "identifier": "date-of-birth-answer",
-                                  "source": "answers"
-                                },
-                                "second_date": {
-                                  "value": "now"
-                                }
-                              },
-                              "transform": "calculate_date_difference"
-                            }
-                          ]
+                          "transform": "calculate_date_difference"
                         }
-                      ],
-                      "text": "{person_name} is {age} old. Is this correct?"
-                    },
-                    "type": "General"
-                  },
-                  "when": {
-                    "==": [
-                      {
-                        "source": "answers",
-                        "identifier": "proxy-answer"
-                      },
-                      "Yes"
-                    ]
-                  }
-                }
-              ],
+                      ]
+                    }
+                  ],
+                  "text": "{person_name} is {age} old. Is this correct?"
+                },
+                "type": "General"
+              },
               "routing_rules": [
                 {
                   "block": "date-of-birth",
@@ -442,7 +350,7 @@
                         "source": "answers",
                         "identifier": "confirm-date-of-birth-answer"
                       },
-                      "No, I need to change their date of birth"
+                      "No, I need to change my date of birth"
                     ]
                   }
                 },
@@ -454,252 +362,133 @@
             },
             {
               "id": "date-of-birth",
-              "question_variants": [
-                {
-                  "question": {
-                    "answers": [
-                      {
-                        "id": "date-of-birth-answer",
-                        "mandatory": true,
-                        "maximum": {
-                          "value": "now"
-                        },
-                        "minimum": {
-                          "offset_by": {
-                            "years": -115
-                          },
-                          "value": "2019-10-13"
-                        },
-                        "type": "Date"
-                      }
-                    ],
-                    "guidance": {
-                      "contents": [
-                        {
-                          "description": "For example 31 12 1970"
-                        }
-                      ]
+              "question": {
+                "answers": [
+                  {
+                    "id": "date-of-birth-answer",
+                    "mandatory": true,
+                    "maximum": {
+                      "value": "now"
                     },
-                    "id": "date-of-birth-question",
-                    "title": "What is your date of birth?",
-                    "type": "General"
-                  },
-                  "when": {
-                    "==": [
-                      {
-                        "source": "answers",
-                        "identifier": "proxy-answer"
+                    "minimum": {
+                      "offset_by": {
+                        "years": -115
                       },
-                      "No, I’m answering for myself"
-                    ]
+                      "value": "2019-10-13"
+                    },
+                    "type": "Date"
                   }
+                ],
+                "guidance": {
+                  "contents": [
+                    {
+                      "description": "For example 31 12 1970"
+                    }
+                  ]
                 },
-                {
-                  "question": {
-                    "answers": [
-                      {
-                        "id": "date-of-birth-answer",
-                        "mandatory": true,
-                        "maximum": {
-                          "value": "now"
-                        },
-                        "minimum": {
-                          "offset_by": {
-                            "years": -115
-                          },
-                          "value": "2019-10-13"
-                        },
-                        "type": "Date"
-                      }
-                    ],
-                    "guidance": {
-                      "contents": [
+                "id": "date-of-birth-question",
+                "title": {
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name_possessive",
+                      "transforms": [
                         {
-                          "description": "For example 31 12 1970"
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "first-name"
+                              },
+                              {
+                                "source": "answers",
+                                "identifier": "last-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        },
+                        {
+                          "arguments": {
+                            "string_to_format": {
+                              "source": "previous_transform"
+                            }
+                          },
+                          "transform": "format_possessive"
                         }
                       ]
-                    },
-                    "id": "date-of-birth-question",
-                    "title": {
-                      "placeholders": [
-                        {
-                          "placeholder": "person_name_possessive",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "delimiter": " ",
-                                "list_to_concatenate": [
-                                  {
-                                    "source": "answers",
-                                    "identifier": "first-name"
-                                  },
-                                  {
-                                    "source": "answers",
-                                    "identifier": "last-name"
-                                  }
-                                ]
-                              },
-                              "transform": "concatenate_list"
-                            },
-                            {
-                              "arguments": {
-                                "string_to_format": {
-                                  "source": "previous_transform"
-                                }
-                              },
-                              "transform": "format_possessive"
-                            }
-                          ]
-                        }
-                      ],
-                      "text": "What is <strong>{person_name_possessive}</strong> date of birth?"
-                    },
-                    "type": "General"
-                  },
-                  "when": {
-                    "==": [
-                      {
-                        "source": "answers",
-                        "identifier": "proxy-answer"
-                      },
-                      "Yes"
-                    ]
-                  }
-                }
-              ],
+                    }
+                  ],
+                  "text": "What is <strong>{person_name_possessive}</strong> date of birth?"
+                },
+                "type": "General"
+              },
               "type": "Question"
             },
             {
               "id": "confirm-sex",
-              "question_variants": [
-                {
-                  "question": {
-                    "answers": [
+              "question": {
+                "answers": [
+                  {
+                    "id": "confirm-sex-answer",
+                    "mandatory": true,
+                    "options": [
                       {
-                        "id": "confirm-sex-answer",
-                        "mandatory": true,
-                        "options": [
-                          {
-                            "label": "Yes, I am {sex-answer}",
-                            "value": "Yes, I am {sex-answer}"
-                          },
-                          {
-                            "label": "No, that is not my sex",
-                            "value": "No, that is not my sex"
-                          }
-                        ],
-                        "type": "Radio"
-                      }
-                    ],
-                    "id": "confirm-sex-question",
-                    "title": {
-                      "placeholders": [
-                        {
-                          "placeholder": "sex-answer",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "source": "answers",
-                                "identifier": "sex-answer"
-                              },
-                              "transform": "copy"
-                            }
-                          ]
-                        }
-                      ],
-                      "text": "You are {sex-answer}. Is this correct?"
-                    },
-                    "type": "General"
-                  },
-                  "when": {
-                    "==": [
-                      {
-                        "source": "answers",
-                        "identifier": "proxy-answer"
+                        "label": "Yes, that is correct",
+                        "value": "Yes, that is correct"
                       },
-                      "No, I’m answering for myself"
-                    ]
-                  }
-                },
-                {
-                  "question": {
-                    "answers": [
                       {
-                        "id": "confirm-sex-answer",
-                        "mandatory": true,
-                        "options": [
-                          {
-                            "label": "Yes, {person_name_possessive} sex is {sex-answer}",
-                            "value": "Yes, {person_name_possessive} sex is {sex-answer}"
-                          },
-                          {
-                            "label": "No, that is not their sex",
-                            "value": "No, that is not their sex"
-                          }
-                        ],
-                        "type": "Radio"
+                        "label": "No, that is not my sex",
+                        "value": "No, that is not my sex"
                       }
                     ],
-                    "id": "confirm-sex-question",
-                    "title": {
-                      "placeholders": [
+                    "type": "Radio"
+                  }
+                ],
+                "id": "confirm-sex-question",
+                "title": {
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name_possessive",
+                      "transforms": [
                         {
-                          "placeholder": "person_name_possessive",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "delimiter": " ",
-                                "list_to_concatenate": [
-                                  {
-                                    "source": "answers",
-                                    "identifier": "first-name"
-                                  },
-                                  {
-                                    "source": "answers",
-                                    "identifier": "last-name"
-                                  }
-                                ]
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "first-name"
                               },
-                              "transform": "concatenate_list"
-                            },
-                            {
-                              "arguments": {
-                                "string_to_format": {
-                                  "source": "previous_transform"
-                                }
-                              },
-                              "transform": "format_possessive"
-                            }
-                          ]
+                              {
+                                "source": "answers",
+                                "identifier": "last-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
                         },
                         {
-                          "placeholder": "sex-answer",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "source": "answers",
-                                "identifier": "sex-answer"
-                              },
-                              "transform": "copy"
+                          "arguments": {
+                            "string_to_format": {
+                              "source": "previous_transform"
                             }
-                          ]
+                          },
+                          "transform": "format_possessive"
                         }
-                      ],
-                      "text": "Is <strong>{person_name_possessive}</strong> sex - {sex-answer}?"
+                      ]
                     },
-                    "type": "General"
-                  },
-                  "when": {
-                    "==": [
-                      {
+                    {
+                      "placeholder": "sex-answer",
+                      "value": {
                         "source": "answers",
-                        "identifier": "proxy-answer"
-                      },
-                      "Yes"
-                    ]
-                  }
-                }
-              ],
+                        "identifier": "sex-answer"
+                      }
+                    }
+                  ],
+                  "text": "Is <strong>{person_name_possessive}</strong> sex - {sex-answer}?"
+                },
+                "type": "General"
+              },
               "routing_rules": [
                 {
                   "block": "sex",
@@ -721,258 +510,68 @@
             },
             {
               "id": "sex",
-              "question_variants": [
-                {
-                  "question": {
-                    "answers": [
+              "question": {
+                "answers": [
+                  {
+                    "id": "sex-answer",
+                    "mandatory": false,
+                    "options": [
                       {
-                        "id": "sex-answer",
-                        "mandatory": false,
-                        "options": [
-                          {
-                            "label": "Female",
-                            "value": "Female"
-                          },
-                          {
-                            "label": "Male",
-                            "value": "Male"
-                          }
-                        ],
-                        "type": "Radio"
-                      }
-                    ],
-                    "guidance": {
-                      "contents": [
-                        {
-                          "description": "A question about gender will follow"
-                        }
-                      ]
-                    },
-                    "id": "sex-question",
-                    "title": "What is your sex?",
-                    "type": "General"
-                  },
-                  "when": {
-                    "and": [
-                      {
-                        "==": [
-                          {
-                            "source": "answers",
-                            "identifier": "proxy-answer"
-                          },
-                          "No, I’m answering for myself"
-                        ]
+                        "label": "Female",
+                        "value": "Female"
                       },
                       {
-                        "<=": [
-                          {
-                            "date": ["now", { "years": -16 }]
-                          },
-                          {
-                            "date": [
+                        "label": "Male",
+                        "value": "Male"
+                      }
+                    ],
+                    "type": "Radio"
+                  }
+                ],
+                "guidance": {
+                  "contents": [
+                    {
+                      "description": "A question about gender will follow"
+                    }
+                  ]
+                },
+                "id": "sex-question",
+                "title": {
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name_possessive",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
                               {
                                 "source": "answers",
-                                "identifier": "date-of-birth-answer"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                },
-                {
-                  "question": {
-                    "answers": [
-                      {
-                        "id": "sex-answer",
-                        "mandatory": false,
-                        "options": [
-                          {
-                            "label": "Female",
-                            "value": "Female"
-                          },
-                          {
-                            "label": "Male",
-                            "value": "Male"
-                          }
-                        ],
-                        "type": "Radio"
-                      }
-                    ],
-                    "guidance": {
-                      "contents": [
-                        {
-                          "description": "A question about gender will follow"
-                        }
-                      ]
-                    },
-                    "id": "sex-question",
-                    "title": {
-                      "placeholders": [
-                        {
-                          "placeholder": "person_name_possessive",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "delimiter": " ",
-                                "list_to_concatenate": [
-                                  {
-                                    "source": "answers",
-                                    "identifier": "first-name"
-                                  },
-                                  {
-                                    "source": "answers",
-                                    "identifier": "last-name"
-                                  }
-                                ]
+                                "identifier": "first-name"
                               },
-                              "transform": "concatenate_list"
-                            },
-                            {
-                              "arguments": {
-                                "string_to_format": {
-                                  "source": "previous_transform"
-                                }
-                              },
-                              "transform": "format_possessive"
-                            }
-                          ]
-                        }
-                      ],
-                      "text": "What is <strong>{person_name_possessive}</strong> sex?"
-                    },
-                    "type": "General"
-                  },
-                  "when": {
-                    "and": [
-                      {
-                        "==": [
-                          {
-                            "source": "answers",
-                            "identifier": "proxy-answer"
-                          },
-                          "Yes"
-                        ]
-                      },
-                      {
-                        "<=": [
-                          {
-                            "date": ["now", { "years": -16 }]
-                          },
-                          {
-                            "date": [
                               {
                                 "source": "answers",
-                                "identifier": "date-of-birth-answer"
+                                "identifier": "last-name"
                               }
                             ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                },
-                {
-                  "question": {
-                    "answers": [
-                      {
-                        "id": "sex-answer",
-                        "mandatory": false,
-                        "options": [
-                          {
-                            "label": "Female",
-                            "value": "Female"
                           },
-                          {
-                            "label": "Male",
-                            "value": "Male"
-                          }
-                        ],
-                        "type": "Radio"
-                      }
-                    ],
-                    "id": "sex-question",
-                    "title": "What is your sex?",
-                    "type": "General"
-                  },
-                  "when": {
-                    "==": [
-                      {
-                        "source": "answers",
-                        "identifier": "proxy-answer"
-                      },
-                      "No, I’m answering for myself"
-                    ]
-                  }
-                },
-                {
-                  "question": {
-                    "answers": [
-                      {
-                        "id": "sex-answer",
-                        "mandatory": false,
-                        "options": [
-                          {
-                            "label": "Female",
-                            "value": "Female"
-                          },
-                          {
-                            "label": "Male",
-                            "value": "Male"
-                          }
-                        ],
-                        "type": "Radio"
-                      }
-                    ],
-                    "id": "sex-question",
-                    "title": {
-                      "placeholders": [
+                          "transform": "concatenate_list"
+                        },
                         {
-                          "placeholder": "person_name_possessive",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "delimiter": " ",
-                                "list_to_concatenate": [
-                                  {
-                                    "source": "answers",
-                                    "identifier": "first-name"
-                                  },
-                                  {
-                                    "source": "answers",
-                                    "identifier": "last-name"
-                                  }
-                                ]
-                              },
-                              "transform": "concatenate_list"
-                            },
-                            {
-                              "arguments": {
-                                "string_to_format": {
-                                  "source": "previous_transform"
-                                }
-                              },
-                              "transform": "format_possessive"
+                          "arguments": {
+                            "string_to_format": {
+                              "source": "previous_transform"
                             }
-                          ]
+                          },
+                          "transform": "format_possessive"
                         }
-                      ],
-                      "text": "What is <strong>{person_name_possessive}</strong> sex?"
-                    },
-                    "type": "General"
-                  },
-                  "when": {
-                    "==": [
-                      {
-                        "source": "answers",
-                        "identifier": "proxy-answer"
-                      },
-                      "Yes"
-                    ]
-                  }
-                }
-              ],
+                      ]
+                    }
+                  ],
+                  "text": "What is <strong>{person_name_possessive}</strong> sex?"
+                },
+                "type": "General"
+              },
               "type": "Question"
             }
           ]

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -75,11 +75,100 @@
                   ]
                 },
                 "type": "General"
+              },
+              "routing_rules": [
+                {
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "number-of-employees-total"
+                      },
+                      2
+                    ]
+                  },
+                  "section": "End"
+                },
+                {
+                  "block": "confirm-zero-employees-block"
+                }
+              ]
+            },
+            {
+              "type": "ConfirmationQuestion",
+              "id": "confirm-zero-employees-block",
+              "skip_conditions": {
+                "when": {
+                  ">": [
+                    {
+                      "source": "answers",
+                      "identifier": "number-of-employees-total"
+                    },
+                    0
+                  ]
+                }
+              },
+              "question": {
+                "type": "General",
+                "answers": [
+                  {
+                    "type": "Radio",
+                    "id": "confirm-zero-employees-answer",
+                    "options": [
+                      {
+                        "label": "Yes this is correct",
+                        "value": "Yes this is correct"
+                      },
+                      {
+                        "label": "No I need to correct this",
+                        "value": "No I need to correct this"
+                      }
+                    ],
+                    "mandatory": true
+                  }
+                ],
+                "id": "confirm-zero-employees-question",
+                "title": {
+                  "text": "The current number of employees for {company_name} is <strong>0</strong>, is this correct?",
+                  "placeholders": [
+                    {
+                      "placeholder": "company_name",
+                      "transforms": [
+                        {
+                          "transform": "first_non_empty_item",
+                          "arguments": {
+                            "items": [
+                              {
+                                "source": "metadata",
+                                "identifier": "trad_as"
+                              },
+                              {
+                                "source": "metadata",
+                                "identifier": "ru_name"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
               }
             }
           ]
         }
-      ]
+      ],
+      "enabled": {
+        "when": {
+          "==": [
+            {
+              "identifier": "number-of-employees-total",
+              "source": "answers"
+            },
+            1
+          ]
+        }
+      }
     },
     {
       "id": "employees-section",

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -1,140 +1,139 @@
 {
-    "mime_type": "application/json/ons/eq",
-    "language": "en",
-    "schema_version": "0.0.1",
-    "survey_id": "139",
-    "theme": "default",
-    "title": "Confirmation Question Test",
-    "data_version": "0.0.3",
-    "description": "A questionnaire to test answers referenced as source before it has been added.",
-    "navigation": {
-        "visible": true
+  "mime_type": "application/json/ons/eq",
+  "language": "en",
+  "schema_version": "0.0.1",
+  "survey_id": "139",
+  "theme": "default",
+  "title": "Confirmation Question Test",
+  "data_version": "0.0.3",
+  "description": "A questionnaire to test answers referenced as source before it has been added.",
+  "navigation": {
+    "visible": true
+  },
+  "metadata": [
+    {
+      "name": "user_id",
+      "type": "string"
     },
-    "metadata": [
+    {
+      "name": "period_id",
+      "type": "string"
+    },
+    {
+      "name": "ru_name",
+      "type": "string"
+    },
+    {
+      "name": "trad_as",
+      "type": "string",
+      "optional": true
+    }
+  ],
+  "questionnaire_flow": {
+    "type": "Linear",
+    "options": {
+      "summary": {
+        "collapsible": false
+      }
+    }
+  },
+  "sections": [
+    {
+      "id": "confirmation-section",
+      "title": "Questions",
+      "groups": [
         {
-            "name": "user_id",
-            "type": "string"
-        },
-        {
-            "name": "period_id",
-            "type": "string"
-        },
-        {
-            "name": "ru_name",
-            "type": "string"
-        },
-        {
-            "name": "trad_as",
-            "type": "string",
-            "optional": true
-        }
-    ],
-    "questionnaire_flow": {
-        "type": "Linear",
-        "options": {
-            "summary": {
-                "collapsible": false
+          "id": "confirmation-block",
+          "title": "Confirmation Question Group",
+          "blocks": [
+            {
+              "id": "number-of-employees-split-block",
+              "type": "Question",
+              "question": {
+                "answers": [
+                  {
+                    "id": "number-of-employees-more-30-hours",
+                    "label": "Number of employees working more than 30 hours per week",
+                    "mandatory": false,
+                    "type": "Number",
+                    "maximum": {
+                      "value": 1000
+                    }
+                  }
+                ],
+                "id": "number-of-employees-split-question",
+                "title": {
+                  "text": "Of the <strong>{number_of_employees_total}</strong> total employees employed, how many male and female employees worked the following hours?",
+                  "placeholders": [
+                    {
+                      "placeholder": "number_of_employees_total",
+                      "value": {
+                        "source": "answers",
+                        "identifier": "number-of-employees-total"
+                      }
+                    }
+                  ]
+                },
+                "type": "General"
+              }
             }
+          ]
         }
+      ]
     },
-    "sections": [
+    {
+      "id": "employees-section",
+      "title": "Questions",
+      "groups": [
         {
-            "id": "confirmation-section",
-            "title": "Questions",
-            "groups": [
-                {
-                    "id": "confirmation-block",
-                    "title": "Confirmation Question Group",
-                    "blocks": [
+          "id": "employees-block",
+          "title": "Employees Question Group",
+          "blocks": [
+            {
+              "id": "number-of-employees-total-block",
+              "question": {
+                "answers": [
+                  {
+                    "id": "number-of-employees-total",
+                    "label": "Total number of employees",
+                    "mandatory": false,
+                    "type": "Number",
+                    "default": 0
+                  }
+                ],
+                "id": "number-of-employees-total-question",
+                "title": {
+                  "text": "How many employees work at {company_name}?",
+                  "placeholders": [
+                    {
+                      "placeholder": "company_name",
+                      "transforms": [
                         {
-                            "id": "number-of-employees-split-block",
-                            "type": "Question",
-                            "question": {
-                                "answers": [
-                                    {
-                                        "id": "number-of-employees-more-30-hours",
-                                        "label": "Number of employees working more than 30 hours per week",
-                                        "mandatory": false,
-                                        "type": "Number",
-                                        "maximum": {
-                                            "value": 1000
-                                            }
-                                        }
-
-                                ],
-                                "id": "number-of-employees-split-question",
-                                "title": {
-                                    "text": "Of the <strong>{number_of_employees_total}</strong> total employees employed, how many male and female employees worked the following hours?",
-                                    "placeholders": [
-                                        {
-                                            "placeholder": "number_of_employees_total",
-                                            "value": {
-                                                "source": "answers",
-                                                "identifier": "number-of-employees-total"
-                                            }
-                                        }
-                                    ]
-                                },
-                                "type": "General"
-                            }
+                          "transform": "first_non_empty_item",
+                          "arguments": {
+                            "items": [
+                              {
+                                "source": "metadata",
+                                "identifier": "trad_as"
+                              },
+                              {
+                                "source": "metadata",
+                                "identifier": "ru_name"
+                              }
+                            ]
+                          }
                         }
-                    ]
-                }
-            ]
-        },
-        {
-            "id": "employees-section",
-            "title": "Questions",
-            "groups": [
-                {
-                    "id": "employees-block",
-                    "title": "Employees Question Group",
-                    "blocks": [
-                        {
-                            "id": "number-of-employees-total-block",
-                            "question": {
-                                "answers": [
-                                    {
-                                        "id": "number-of-employees-total",
-                                        "label": "Total number of employees",
-                                        "mandatory": false,
-                                        "type": "Number",
-                                        "default": 0
-                                    }
-                                ],
-                                "id": "number-of-employees-total-question",
-                                "title": {
-                                    "text": "How many employees work at {company_name}?",
-                                    "placeholders": [
-                                        {
-                                            "placeholder": "company_name",
-                                            "transforms": [
-                                                {
-                                                    "transform": "first_non_empty_item",
-                                                    "arguments": {
-                                                        "items": [
-                                                            {
-                                                                "source": "metadata",
-                                                                "identifier": "trad_as"
-                                                            },
-                                                            {
-                                                                "source": "metadata",
-                                                                "identifier": "ru_name"
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                "type": "General"
-                            },
-                            "type": "Question"
-                        }
-                    ]
-                }
-            ]
+                      ]
+                    }
+                  ]
+                },
+                "type": "General"
+              },
+              "type": "Question"
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -43,7 +43,7 @@
       "title": "Questions",
       "groups": [
         {
-          "id": "confirmation-block",
+          "id": "confirmation-group",
           "title": "Confirmation Question Group",
           "skip_conditions": {
             "when": {

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -39,6 +39,835 @@
   },
   "sections": [
     {
+      "summary": {
+        "show_on_completion": true,
+        "items": [
+          {
+            "type": "List",
+            "for_list": "people",
+            "title": "Household members",
+            "add_link_text": "Add someone to this household",
+            "empty_list_text": "There are no householders"
+          }
+        ]
+      },
+      "id": "household-section",
+      "title": "Household",
+      "groups": [
+        {
+          "id": "household-group",
+          "title": "List",
+          "blocks": [
+            {
+              "id": "list-collector",
+              "type": "ListCollector",
+              "for_list": "people",
+              "question": {
+                "id": "confirmation-question",
+                "type": "General",
+                "title": "Does anyone else live here?",
+                "answers": [
+                  {
+                    "id": "anyone-else",
+                    "mandatory": true,
+                    "type": "Radio",
+                    "options": [
+                      {
+                        "label": "Yes",
+                        "value": "Yes",
+                        "action": {
+                          "type": "RedirectToListAddBlock"
+                        }
+                      },
+                      {
+                        "label": "No",
+                        "value": "No"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "add_block": {
+                "id": "add-person",
+                "type": "ListAddQuestion",
+                "question": {
+                  "id": "add-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "edit_block": {
+                "id": "edit-person",
+                "type": "ListEditQuestion",
+                "question": {
+                  "id": "edit-question",
+                  "type": "General",
+                  "title": "What is the name of the person?",
+                  "answers": [
+                    {
+                      "id": "first-name",
+                      "label": "First name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    },
+                    {
+                      "id": "last-name",
+                      "label": "Last name",
+                      "mandatory": true,
+                      "type": "TextField"
+                    }
+                  ]
+                }
+              },
+              "remove_block": {
+                "id": "remove-person",
+                "type": "ListRemoveQuestion",
+                "question": {
+                  "id": "remove-question",
+                  "type": "General",
+                  "title": "Are you sure you want to remove this person?",
+                  "answers": [
+                    {
+                      "id": "remove-confirmation",
+                      "mandatory": true,
+                      "type": "Radio",
+                      "options": [
+                        {
+                          "label": "Yes",
+                          "value": "Yes",
+                          "action": {
+                            "type": "RemoveListItemAndAnswers"
+                          }
+                        },
+                        {
+                          "label": "No",
+                          "value": "No"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "summary": {
+                "title": "Household members",
+                "item_title": {
+                  "text": "{person_name}",
+                  "placeholders": [
+                    {
+                      "placeholder": "person_name",
+                      "transforms": [
+                        {
+                          "arguments": {
+                            "delimiter": " ",
+                            "list_to_concatenate": [
+                              {
+                                "source": "answers",
+                                "identifier": "first-name"
+                              },
+                              {
+                                "source": "answers",
+                                "identifier": "last-name"
+                              }
+                            ]
+                          },
+                          "transform": "concatenate_list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "personal-details-section",
+      "title": "Personal Details",
+      "summary": {
+        "show_on_completion": true
+      },
+      "repeat": {
+        "for_list": "people",
+        "title": {
+          "text": "{person_name}",
+          "placeholders": [
+            {
+              "placeholder": "person_name",
+              "transforms": [
+                {
+                  "transform": "concatenate_list",
+                  "arguments": {
+                    "list_to_concatenate": [
+                      {
+                        "source": "answers",
+                        "identifier": "first-name"
+                      },
+                      {
+                        "source": "answers",
+                        "identifier": "last-name"
+                      }
+                    ],
+                    "delimiter": " "
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "groups": [
+        {
+          "id": "personal-details-group",
+          "title": "Personal Details",
+          "blocks": [
+            {
+              "id": "proxy",
+              "question": {
+                "answers": [
+                  {
+                    "default": "Yes",
+                    "id": "proxy-answer",
+                    "mandatory": false,
+                    "options": [
+                      {
+                        "label": "No, I’m answering for myself",
+                        "value": "No, I’m answering for myself"
+                      },
+                      {
+                        "label": "Yes",
+                        "value": "Yes"
+                      }
+                    ],
+                    "type": "Radio"
+                  }
+                ],
+                "id": "proxy-question",
+                "title": "Are you answering the questions on behalf of someone else?",
+                "type": "General"
+              },
+              "type": "Question"
+            },
+            {
+              "id": "confirm-dob",
+              "question_variants": [
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "confirm-date-of-birth-answer",
+                        "mandatory": true,
+                        "options": [
+                          {
+                            "label": {
+                              "placeholders": [
+                                {
+                                  "placeholder": "age",
+                                  "transforms": [
+                                    {
+                                      "arguments": {
+                                        "first_date": {
+                                          "identifier": "date-of-birth-answer",
+                                          "source": "answers"
+                                        },
+                                        "second_date": {
+                                          "value": "now"
+                                        }
+                                      },
+                                      "transform": "calculate_date_difference"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "text": "Yes, I am {age} old"
+                            },
+                            "value": "Yes, I am {age} old"
+                          },
+                          {
+                            "label": "No, I need to change my date of birth",
+                            "value": "No, I need to change my date of birth"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "id": "confirm-date-of-birth",
+                    "title": {
+                      "placeholders": [
+                        {
+                          "placeholder": "age",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "first_date": {
+                                  "identifier": "date-of-birth-answer",
+                                  "source": "answers"
+                                },
+                                "second_date": {
+                                  "value": "now"
+                                }
+                              },
+                              "transform": "calculate_date_difference"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "You are {age} old. Is this correct?"
+                    },
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "proxy-answer"
+                      },
+                      "No, I’m answering for myself"
+                    ]
+                  }
+                },
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "confirm-date-of-birth-answer",
+                        "mandatory": true,
+                        "options": [
+                          {
+                            "label": {
+                              "placeholders": [
+                                {
+                                  "placeholder": "person_name",
+                                  "transforms": [
+                                    {
+                                      "arguments": {
+                                        "delimiter": " ",
+                                        "list_to_concatenate": [
+                                          {
+                                            "source": "answers",
+                                            "identifier": "first-name"
+                                          },
+                                          {
+                                            "source": "answers",
+                                            "identifier": "last-name"
+                                          }
+                                        ]
+                                      },
+                                      "transform": "concatenate_list"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "placeholder": "age",
+                                  "transforms": [
+                                    {
+                                      "arguments": {
+                                        "first_date": {
+                                          "identifier": "date-of-birth-answer",
+                                          "source": "answers"
+                                        },
+                                        "second_date": {
+                                          "value": "now"
+                                        }
+                                      },
+                                      "transform": "calculate_date_difference"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "text": "Yes, {person_name} is {age} old"
+                            },
+                            "value": "Yes, {person_name} is {age} old"
+                          },
+                          {
+                            "label": "No, I need to change their date of birth",
+                            "value": "No, I need to change their date of birth"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "id": "confirm-date-of-birth",
+                    "title": {
+                      "placeholders": [
+                        {
+                          "placeholder": "person_name",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": [
+                                  {
+                                    "source": "answers",
+                                    "identifier": "first-name"
+                                  },
+                                  {
+                                    "source": "answers",
+                                    "identifier": "last-name"
+                                  }
+                                ]
+                              },
+                              "transform": "concatenate_list"
+                            }
+                          ]
+                        },
+                        {
+                          "placeholder": "age",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "first_date": {
+                                  "identifier": "date-of-birth-answer",
+                                  "source": "answers"
+                                },
+                                "second_date": {
+                                  "value": "now"
+                                }
+                              },
+                              "transform": "calculate_date_difference"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "{person_name} is {age} old. Is this correct?"
+                    },
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "proxy-answer"
+                      },
+                      "Yes"
+                    ]
+                  }
+                }
+              ],
+              "routing_rules": [
+                {
+                  "block": "date-of-birth",
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "confirm-date-of-birth-answer"
+                      },
+                      "No, I need to change my date of birth"
+                    ]
+                  }
+                },
+                {
+                  "block": "date-of-birth",
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "confirm-date-of-birth-answer"
+                      },
+                      "No, I need to change their date of birth"
+                    ]
+                  }
+                },
+                {
+                  "block": "sex"
+                }
+              ],
+              "type": "ConfirmationQuestion"
+            },
+            {
+              "id": "date-of-birth",
+              "question_variants": [
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "date-of-birth-answer",
+                        "mandatory": true,
+                        "maximum": {
+                          "value": "now"
+                        },
+                        "minimum": {
+                          "offset_by": {
+                            "years": -115
+                          },
+                          "value": "2019-10-13"
+                        },
+                        "type": "Date"
+                      }
+                    ],
+                    "guidance": {
+                      "contents": [
+                        {
+                          "description": "For example 31 12 1970"
+                        }
+                      ]
+                    },
+                    "id": "date-of-birth-question",
+                    "title": "What is your date of birth?",
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "proxy-answer"
+                      },
+                      "No, I’m answering for myself"
+                    ]
+                  }
+                },
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "date-of-birth-answer",
+                        "mandatory": true,
+                        "maximum": {
+                          "value": "now"
+                        },
+                        "minimum": {
+                          "offset_by": {
+                            "years": -115
+                          },
+                          "value": "2019-10-13"
+                        },
+                        "type": "Date"
+                      }
+                    ],
+                    "guidance": {
+                      "contents": [
+                        {
+                          "description": "For example 31 12 1970"
+                        }
+                      ]
+                    },
+                    "id": "date-of-birth-question",
+                    "title": {
+                      "placeholders": [
+                        {
+                          "placeholder": "person_name_possessive",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": [
+                                  {
+                                    "source": "answers",
+                                    "identifier": "first-name"
+                                  },
+                                  {
+                                    "source": "answers",
+                                    "identifier": "last-name"
+                                  }
+                                ]
+                              },
+                              "transform": "concatenate_list"
+                            },
+                            {
+                              "arguments": {
+                                "string_to_format": {
+                                  "source": "previous_transform"
+                                }
+                              },
+                              "transform": "format_possessive"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "What is <strong>{person_name_possessive}</strong> date of birth?"
+                    },
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "proxy-answer"
+                      },
+                      "Yes"
+                    ]
+                  }
+                }
+              ],
+              "type": "Question"
+            },
+            {
+              "id": "sex",
+              "question_variants": [
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "sex-answer",
+                        "mandatory": false,
+                        "options": [
+                          {
+                            "label": "Female",
+                            "value": "Female"
+                          },
+                          {
+                            "label": "Male",
+                            "value": "Male"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "guidance": {
+                      "contents": [
+                        {
+                          "description": "A question about gender will follow"
+                        }
+                      ]
+                    },
+                    "id": "sex-question",
+                    "title": "What is your sex?",
+                    "type": "General"
+                  },
+                  "when": {
+                    "and": [
+                      {
+                        "==": [
+                          {
+                            "source": "answers",
+                            "identifier": "proxy-answer"
+                          },
+                          "No, I’m answering for myself"
+                        ]
+                      },
+                      {
+                        "<=": [
+                          {
+                            "date": ["now", { "years": -16 }]
+                          },
+                          {
+                            "date": [
+                              {
+                                "source": "answers",
+                                "identifier": "date-of-birth-answer"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "sex-answer",
+                        "mandatory": false,
+                        "options": [
+                          {
+                            "label": "Female",
+                            "value": "Female"
+                          },
+                          {
+                            "label": "Male",
+                            "value": "Male"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "guidance": {
+                      "contents": [
+                        {
+                          "description": "A question about gender will follow"
+                        }
+                      ]
+                    },
+                    "id": "sex-question",
+                    "title": {
+                      "placeholders": [
+                        {
+                          "placeholder": "person_name_possessive",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": [
+                                  {
+                                    "source": "answers",
+                                    "identifier": "first-name"
+                                  },
+                                  {
+                                    "source": "answers",
+                                    "identifier": "last-name"
+                                  }
+                                ]
+                              },
+                              "transform": "concatenate_list"
+                            },
+                            {
+                              "arguments": {
+                                "string_to_format": {
+                                  "source": "previous_transform"
+                                }
+                              },
+                              "transform": "format_possessive"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "What is <strong>{person_name_possessive}</strong> sex?"
+                    },
+                    "type": "General"
+                  },
+                  "when": {
+                    "and": [
+                      {
+                        "==": [
+                          {
+                            "source": "answers",
+                            "identifier": "proxy-answer"
+                          },
+                          "Yes"
+                        ]
+                      },
+                      {
+                        "<=": [
+                          {
+                            "date": ["now", { "years": -16 }]
+                          },
+                          {
+                            "date": [
+                              {
+                                "source": "answers",
+                                "identifier": "date-of-birth-answer"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "sex-answer",
+                        "mandatory": false,
+                        "options": [
+                          {
+                            "label": "Female",
+                            "value": "Female"
+                          },
+                          {
+                            "label": "Male",
+                            "value": "Male"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "id": "sex-question",
+                    "title": "What is your sex?",
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "proxy-answer"
+                      },
+                      "No, I’m answering for myself"
+                    ]
+                  }
+                },
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "sex-answer",
+                        "mandatory": false,
+                        "options": [
+                          {
+                            "label": "Female",
+                            "value": "Female"
+                          },
+                          {
+                            "label": "Male",
+                            "value": "Male"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "id": "sex-question",
+                    "title": {
+                      "placeholders": [
+                        {
+                          "placeholder": "person_name_possessive",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": [
+                                  {
+                                    "source": "answers",
+                                    "identifier": "first-name"
+                                  },
+                                  {
+                                    "source": "answers",
+                                    "identifier": "last-name"
+                                  }
+                                ]
+                              },
+                              "transform": "concatenate_list"
+                            },
+                            {
+                              "arguments": {
+                                "string_to_format": {
+                                  "source": "previous_transform"
+                                }
+                              },
+                              "transform": "format_possessive"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "What is <strong>{person_name_possessive}</strong> sex?"
+                    },
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "proxy-answer"
+                      },
+                      "Yes"
+                    ]
+                  }
+                }
+              ],
+              "type": "Question"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "confirmation-section",
       "title": "Questions",
       "groups": [

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -350,23 +350,6 @@
                                       "transform": "concatenate_list"
                                     }
                                   ]
-                                },
-                                {
-                                  "placeholder": "age",
-                                  "transforms": [
-                                    {
-                                      "arguments": {
-                                        "first_date": {
-                                          "identifier": "date-of-birth-answer",
-                                          "source": "answers"
-                                        },
-                                        "second_date": {
-                                          "value": "now"
-                                        }
-                                      },
-                                      "transform": "calculate_date_difference"
-                                    }
-                                  ]
                                 }
                               ],
                               "text": "Yes, {person_name} is that age"

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -608,6 +608,156 @@
               "type": "Question"
             },
             {
+              "id": "confirm-sex",
+              "question_variants": [
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "confirm-sex-answer",
+                        "mandatory": true,
+                        "options": [
+                          {
+                            "label": "Yes, I am {sex-answer}",
+                            "value": "Yes, I am {sex-answer}"
+                          },
+                          {
+                            "label": "No, that is not my sex",
+                            "value": "No, that is not my sex"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "id": "confirm-sex-question",
+                    "title": {
+                      "placeholders": [
+                        {
+                          "placeholder": "sex-answer",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "source": "answers",
+                                "identifier": "sex-answer"
+                              },
+                              "transform": "copy"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "You are {sex-answer}. Is this correct?"
+                    },
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "proxy-answer"
+                      },
+                      "No, I’m answering for myself"
+                    ]
+                  }
+                },
+                {
+                  "question": {
+                    "answers": [
+                      {
+                        "id": "confirm-sex-answer",
+                        "mandatory": true,
+                        "options": [
+                          {
+                            "label": "Yes, {person_name_possessive} sex is {sex-answer}",
+                            "value": "Yes, {person_name_possessive} sex is {sex-answer}"
+                          },
+                          {
+                            "label": "No, that is not their sex",
+                            "value": "No, that is not their sex"
+                          }
+                        ],
+                        "type": "Radio"
+                      }
+                    ],
+                    "id": "confirm-sex-question",
+                    "title": {
+                      "placeholders": [
+                        {
+                          "placeholder": "person_name_possessive",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "delimiter": " ",
+                                "list_to_concatenate": [
+                                  {
+                                    "source": "answers",
+                                    "identifier": "first-name"
+                                  },
+                                  {
+                                    "source": "answers",
+                                    "identifier": "last-name"
+                                  }
+                                ]
+                              },
+                              "transform": "concatenate_list"
+                            },
+                            {
+                              "arguments": {
+                                "string_to_format": {
+                                  "source": "previous_transform"
+                                }
+                              },
+                              "transform": "format_possessive"
+                            }
+                          ]
+                        },
+                        {
+                          "placeholder": "sex-answer",
+                          "transforms": [
+                            {
+                              "arguments": {
+                                "source": "answers",
+                                "identifier": "sex-answer"
+                              },
+                              "transform": "copy"
+                            }
+                          ]
+                        }
+                      ],
+                      "text": "Is <strong>{person_name_possessive}</strong> sex - {sex-answer}?"
+                    },
+                    "type": "General"
+                  },
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "proxy-answer"
+                      },
+                      "Yes"
+                    ]
+                  }
+                }
+              ],
+              "routing_rules": [
+                {
+                  "block": "sex",
+                  "when": {
+                    "==": [
+                      {
+                        "source": "answers",
+                        "identifier": "confirm-sex-answer"
+                      },
+                      "No, that is not my sex"
+                    ]
+                  }
+                },
+                {
+                 "section": "End"
+                }
+              ],
+              "type": "ConfirmationQuestion"
+            },
+            {
               "id": "sex",
               "question_variants": [
                 {

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -274,29 +274,8 @@
                         "mandatory": true,
                         "options": [
                           {
-                            "label": {
-                              "placeholders": [
-                                {
-                                  "placeholder": "age",
-                                  "transforms": [
-                                    {
-                                      "arguments": {
-                                        "first_date": {
-                                          "identifier": "date-of-birth-answer",
-                                          "source": "answers"
-                                        },
-                                        "second_date": {
-                                          "value": "now"
-                                        }
-                                      },
-                                      "transform": "calculate_date_difference"
-                                    }
-                                  ]
-                                }
-                              ],
-                              "text": "Yes, I am {age} old"
-                            },
-                            "value": "Yes, I am {age} old"
+                            "label": "Yes, that is my age",
+                            "value": "Yes, that is my age"
                           },
                           {
                             "label": "No, I need to change my date of birth",
@@ -390,9 +369,9 @@
                                   ]
                                 }
                               ],
-                              "text": "Yes, {person_name} is {age} old"
+                              "text": "Yes, {person_name} is that age"
                             },
-                            "value": "Yes, {person_name} is {age} old"
+                            "value": "Yes, {person_name} is that age"
                           },
                           {
                             "label": "No, I need to change their date of birth",
@@ -752,7 +731,7 @@
                   }
                 },
                 {
-                 "section": "End"
+                  "section": "End"
                 }
               ],
               "type": "ConfirmationQuestion"

--- a/tests/schemas/invalid/test_invalid_answer_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_answer_source_reference.json
@@ -45,6 +45,17 @@
         {
           "id": "confirmation-block",
           "title": "Confirmation Question Group",
+          "skip_conditions": {
+            "when": {
+              ">": [
+                {
+                  "source": "answers",
+                  "identifier": "number-of-employees-total"
+                },
+                3
+              ]
+            }
+          },
           "blocks": [
             {
               "id": "number-of-employees-split-block",

--- a/tests/schemas/invalid/test_invalid_list_source_reference.json
+++ b/tests/schemas/invalid/test_invalid_list_source_reference.json
@@ -40,64 +40,11 @@
               "content": {
                 "contents": [
                   {
-                    "description": {
-                      "placeholders": [
-                        {
-                          "placeholder": "person_name",
-                          "transforms": [
-                            {
-                              "arguments": {
-                                "delimiter": " ",
-                                "list_to_concatenate": [
-                                  {
-                                    "source": "answers",
-                                    "identifier": "first-name"
-                                  },
-                                  {
-                                    "source": "answers",
-                                    "identifier": "last-name"
-                                  }
-                                ]
-                              },
-                              "transform": "concatenate_list"
-                            }
-                          ]
-                        }
-                      ],
-                      "text": "In this section, we are going to ask you questions about <strong>{person_name}</strong>."
-                    }
-                  },
-                  {
                     "list": ["date of birth"],
                     "title": "You will need to know personal details such as"
                   }
                 ],
-                "title": {
-                  "placeholders": [
-                    {
-                      "placeholder": "person_name",
-                      "transforms": [
-                        {
-                          "arguments": {
-                            "delimiter": " ",
-                            "list_to_concatenate": [
-                              {
-                                "source": "answers",
-                                "identifier": "first-name"
-                              },
-                              {
-                                "source": "answers",
-                                "identifier": "last-name"
-                              }
-                            ]
-                          },
-                          "transform": "concatenate_list"
-                        }
-                      ]
-                    }
-                  ],
-                  "text": "{person_name}"
-                }
+                "title": "A person"
               },
               "page_title": "Individual interstitial",
               "id": "individual-interstitial",
@@ -156,32 +103,8 @@
                   }
                 ],
                 "id": "proxy-question",
-                "title": {
-                  "placeholders": [
-                    {
-                      "placeholder": "person_name",
-                      "transforms": [
-                        {
-                          "arguments": {
-                            "delimiter": " ",
-                            "list_to_concatenate": [
-                              {
-                                "source": "answers",
-                                "identifier": "first-name"
-                              },
-                              {
-                                "source": "answers",
-                                "identifier": "last-name"
-                              }
-                            ]
-                          },
-                          "transform": "concatenate_list"
-                        }
-                      ]
-                    }
-                  ],
-                  "text": "Are you <strong>{person_name}?</strong>"
-                },
+                "title": "Are you <strong>the person answering?</strong>",
+
                 "type": "General"
               },
               "type": "Question"
@@ -581,18 +504,7 @@
                   },
                   "answers": [
                     {
-                      "label": {
-                        "text": "Monthly expenditure on {utility_bill} bills",
-                        "placeholders": [
-                          {
-                            "placeholder": "utility_bill",
-                            "value": {
-                              "source": "answers",
-                              "identifier": "utility-bill-name"
-                            }
-                          }
-                        ]
-                      },
+                      "label": "Monthly expenditure on bills",
                       "id": "utility-bill-monthly-cost",
                       "type": "Currency",
                       "mandatory": true,

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -433,11 +433,6 @@ def test_answer_as_source_referenced_before_created():
             "been added.",
         },
         {
-            "block_id": "confirm-dob",
-            "message": "Answer 'date-of-birth-answer' referenced as source before it has "
-            "been added.",
-        },
-        {
             "block_id": "confirm-sex",
             "message": "Answer 'sex-answer' referenced as source before it has been added.",
         },

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -418,29 +418,29 @@ def test_answer_as_source_referenced_before_created():
 
     expected_errors = [
         {
-            "group_name": "confirmation-block",
+            "group": "confirmation-group",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },
         {
-            "group_name": "confirmation-block",
+            "block": "number-of-employees-split-block",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },
         {
-            "group_name": "confirmation-block",
+            "block": "number-of-employees-split-block",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },
         {
-            "group_name": "confirmation-block",
+            "block": "confirm-zero-employees-block",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },
         {
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
-            "section_name": "confirmation-section",
+            "section": "confirmation-section",
         },
     ]
 

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -410,3 +410,35 @@ def test_invalid_calculated_or_grand_calculated_summary_id_in_value_source():
     validator.validate()
 
     assert validator.errors == expected_errors
+
+
+def test_answer_as_source_referenced_before_created():
+    filename = "schemas/invalid/test_invalid_answer_source_reference.json"
+    validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
+
+    expected_errors = [
+        {
+            "group_name": "confirmation-block",
+            "message": "Answer 'number-of-employees-total' referenced as source before "
+            "it has been added.",
+        },
+        {
+            "group_name": "confirmation-block",
+            "message": "Answer 'number-of-employees-total' referenced as source before "
+            "it has been added.",
+        },
+        {
+            "group_name": "confirmation-block",
+            "message": "Answer 'number-of-employees-total' referenced as source before "
+            "it has been added.",
+        },
+        {
+            "message": "Answer 'number-of-employees-total' referenced as source before "
+            "it has been added.",
+            "section_name": "confirmation-section",
+        },
+    ]
+
+    validator.validate()
+
+    assert validator.errors == expected_errors

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -414,8 +414,8 @@ def test_invalid_calculated_or_grand_calculated_summary_id_in_value_source():
 
 def test_answer_as_source_referenced_before_created():
     """
-    The schema being validated contains blocks with question variants,
-    resulting in duplicated expected errors due to the same answer source being referenced multiple times within that block.
+    The schema being validated contains blocks where an invalid answer source being referenced multiple times within that block,
+    resulting in duplicated expected errors.
     """
     filename = "schemas/invalid/test_invalid_answer_source_reference.json"
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -418,54 +418,54 @@ def test_answer_as_source_referenced_before_created():
 
     expected_errors = [
         {
-            "block": "confirm-dob",
+            "block_id": "confirm-dob",
             "message": "Answer 'date-of-birth-answer' referenced as source before it has "
             "been added.",
         },
         {
-            "block": "confirm-dob",
+            "block_id": "confirm-dob",
             "message": "Answer 'date-of-birth-answer' referenced as source before it has "
             "been added.",
         },
         {
-            "block": "confirm-dob",
+            "block_id": "confirm-dob",
             "message": "Answer 'date-of-birth-answer' referenced as source before it has "
             "been added.",
         },
         {
-            "block": "confirm-dob",
+            "block_id": "confirm-dob",
             "message": "Answer 'date-of-birth-answer' referenced as source before it has "
             "been added.",
         },
         {
-            "group": "confirmation-group",
+            "group_d": "confirmation-group",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },
         {
-            "block": "number-of-employees-split-block",
+            "block_id": "number-of-employees-split-block",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },
         {
-            "block": "number-of-employees-split-block",
+            "block_id": "number-of-employees-split-block",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },
         {
-            "block": "confirm-zero-employees-block",
+            "block_id": "confirm-zero-employees-block",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },
         {
-            "block": "any-other-companies-or-branches",
+            "block_id": "any-other-companies-or-branches",
             "message": "Answer 'any-companies-or-branches-answer' referenced as source "
             "before it has been added.",
         },
         {
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
-            "section": "confirmation-section",
+            "section_id": "confirmation-section",
         },
     ]
 

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -437,6 +437,11 @@ def test_answer_as_source_referenced_before_created():
             "it has been added.",
             "section_name": "confirmation-section",
         },
+        {
+            "group_name": "confirmation-block",
+            "message": "Answer 'number-of-employees-total' referenced as source before "
+            "it has been added.",
+        },
     ]
 
     validator.validate()

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -97,6 +97,10 @@ def test_invalid_placeholder_answer_ids():
 
     expected_errors = [
         {
+            "identifier": "invalid-answer0",
+            "message": ValueSourceValidator.ANSWER_SOURCE_REFERENCE_INVALID,
+        },
+        {
             "message": ValueSourceValidator.ANSWER_SOURCE_REFERENCE_INVALID,
             "identifier": "invalid-answer0",
             "json_path": "groups.[0].blocks.[0].question.answers.[1].description.placeholders.[0].value.identifier",

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -413,6 +413,10 @@ def test_invalid_calculated_or_grand_calculated_summary_id_in_value_source():
 
 
 def test_answer_as_source_referenced_before_created():
+    """
+    The schema being validated contains blocks with question variants,
+    resulting in duplicated expected errors due to the same answer source being referenced multiple times within that block.
+    """
     filename = "schemas/invalid/test_invalid_answer_source_reference.json"
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
@@ -467,7 +471,6 @@ def test_answer_as_source_referenced_before_created():
         },
     ]
     validator.validate()
-    print(str(validator.errors))
     assert validator.errors == expected_errors
 
 

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -427,17 +427,9 @@ def test_answer_as_source_referenced_before_created():
             "been added.",
         },
         {
-            "block_id": "confirm-dob",
-            "message": "Answer 'date-of-birth-answer' referenced as source before it has "
-            "been added.",
-        },
-        {
             "block_id": "confirm-sex",
-            "message": "Answer 'sex-answer' referenced as source before it has been added.",
-        },
-        {
-            "block_id": "confirm-sex",
-            "message": "Answer 'sex-answer' referenced as source before it has been added.",
+            "message": "Answer 'sex-answer' referenced as source before it has been "
+            "added.",
         },
         {
             "group_id": "confirmation-group",

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -458,6 +458,11 @@ def test_answer_as_source_referenced_before_created():
             "it has been added.",
         },
         {
+            "block": "any-other-companies-or-branches",
+            "message": "Answer 'any-companies-or-branches-answer' referenced as source "
+            "before it has been added.",
+        },
+        {
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
             "section": "confirmation-section",

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -438,6 +438,14 @@ def test_answer_as_source_referenced_before_created():
             "been added.",
         },
         {
+            "block_id": "confirm-sex",
+            "message": "Answer 'sex-answer' referenced as source before it has been added.",
+        },
+        {
+            "block_id": "confirm-sex",
+            "message": "Answer 'sex-answer' referenced as source before it has been added.",
+        },
+        {
             "group_id": "confirmation-group",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
@@ -469,6 +477,7 @@ def test_answer_as_source_referenced_before_created():
         },
     ]
     validator.validate()
+    print(str(validator.errors))
     assert validator.errors == expected_errors
 
 
@@ -527,7 +536,6 @@ def test_list_as_source_referenced_before_created():
     ]
 
     validator.validate()
-
     assert validator.errors == expected_errors
 
 
@@ -552,5 +560,4 @@ def test_list_and_answer_source_referenced_before_created_repeating_blocks():
     ]
 
     validator.validate()
-
     assert validator.errors == expected_errors

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -418,7 +418,6 @@ def test_answer_as_source_referenced_before_created():
 
     expected_errors = [
         {
-
             "block_id": "confirm-dob",
             "message": "Answer 'date-of-birth-answer' referenced as source before it has "
             "been added.",
@@ -468,8 +467,12 @@ def test_answer_as_source_referenced_before_created():
             "it has been added.",
             "section_id": "confirmation-section",
         },
+    ]
+    validator.validate()
+    assert validator.errors == expected_errors
 
- def test_list_as_source_referenced_before_created():
+
+def test_list_as_source_referenced_before_created():
     filename = "schemas/invalid/test_invalid_list_source_reference.json"
     validator = QuestionnaireValidator(_open_and_load_schema_file(filename))
 
@@ -528,7 +531,7 @@ def test_answer_as_source_referenced_before_created():
     assert validator.errors == expected_errors
 
 
-def test_list_as_source_referenced_before_created_repeating_blocks():
+def test_list_and_answer_source_referenced_before_created_repeating_blocks():
     filename = (
         "schemas/invalid/test_invalid_list_source_reference_repeating_blocks.json"
     )
@@ -536,11 +539,16 @@ def test_list_as_source_referenced_before_created_repeating_blocks():
 
     expected_errors = [
         {
+            "block_id": "any-other-companies-or-branches",
+            "message": "Answer 'company-or-branch-name' referenced as source before it "
+            "has been added.",
+        },
+        {
+            "block_id": "any-other-companies-or-branches",
             "list_id": "companies",
             "message": error_messages.LIST_REFERENCED_BEFORE_CREATED,
-            "block_id": "any-other-companies-or-branches",
             "section_id": "section-companies",
-        }
+        },
     ]
 
     validator.validate()

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -428,11 +428,6 @@ def test_answer_as_source_referenced_before_created():
             "been added.",
         },
         {
-            "block_id": "confirm-dob",
-            "message": "Answer 'date-of-birth-answer' referenced as source before it has "
-            "been added.",
-        },
-        {
             "block_id": "confirm-sex",
             "message": "Answer 'sex-answer' referenced as source before it has been added.",
         },

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -418,6 +418,26 @@ def test_answer_as_source_referenced_before_created():
 
     expected_errors = [
         {
+            "block": "confirm-dob",
+            "message": "Answer 'date-of-birth-answer' referenced as source before it has "
+            "been added.",
+        },
+        {
+            "block": "confirm-dob",
+            "message": "Answer 'date-of-birth-answer' referenced as source before it has "
+            "been added.",
+        },
+        {
+            "block": "confirm-dob",
+            "message": "Answer 'date-of-birth-answer' referenced as source before it has "
+            "been added.",
+        },
+        {
+            "block": "confirm-dob",
+            "message": "Answer 'date-of-birth-answer' referenced as source before it has "
+            "been added.",
+        },
+        {
             "group": "confirmation-group",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -438,7 +438,7 @@ def test_answer_as_source_referenced_before_created():
             "been added.",
         },
         {
-            "group_d": "confirmation-group",
+            "group_id": "confirmation-group",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
         },

--- a/tests/test_questionnaire_validator.py
+++ b/tests/test_questionnaire_validator.py
@@ -433,14 +433,14 @@ def test_answer_as_source_referenced_before_created():
             "it has been added.",
         },
         {
-            "message": "Answer 'number-of-employees-total' referenced as source before "
-            "it has been added.",
-            "section_name": "confirmation-section",
-        },
-        {
             "group_name": "confirmation-block",
             "message": "Answer 'number-of-employees-total' referenced as source before "
             "it has been added.",
+        },
+        {
+            "message": "Answer 'number-of-employees-total' referenced as source before "
+            "it has been added.",
+            "section_name": "confirmation-section",
         },
     ]
 


### PR DESCRIPTION
### What is the context of this PR?
Adds validation of objects referencing answers sources, no longer answer source for a given block can be referenced in a section that precedes the section in which the answer itself was set. Order of Block indexes is also checked, as well as group and section level answer source rules like "enabled" and "skip conditions".

### How to review
New invalid schema added and new unit test that checks the error message.

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation

