### PR TITLE
Add Localhost to Allowed Base Domains 

### DIFF
--- a/api.py
+++ b/api.py
@@ -17,7 +17,7 @@ ALLOWED_FULL_DOMAINS = {
     "https://raw.githubusercontent.com/",
 }
 
-ALLOWED_BASE_DOMAINS = {"onsdigital.uk"}
+ALLOWED_BASE_DOMAINS = {"onsdigital.uk","localhost"}
 
 ALLOWED_REPO_OWNERS = {"ONSdigital"}
 

--- a/api.py
+++ b/api.py
@@ -17,7 +17,7 @@ ALLOWED_FULL_DOMAINS = {
     "https://raw.githubusercontent.com/",
 }
 
-ALLOWED_BASE_DOMAINS = {"onsdigital.uk","localhost"}
+ALLOWED_BASE_DOMAINS = {"onsdigital.uk", "localhost"}
 
 ALLOWED_REPO_OWNERS = {"ONSdigital"}
 


### PR DESCRIPTION
### What is the context of this PR?
Validator is not working in Runner locally because localhost is not part of the allowed base domains in validator. This PR adds `localhost` to the allowed domains dictionary

### How to review
Run make run validator in Runner pointing to the tag `add-local-host-domain-to-allowed-list`
Test to see `make validate-test-schemas `works now

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
