### PR TITLE
Pin Compromised NPM Dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "ajv": "^8.11.0",
         "axios": "*",
-        "debug": "^4.3.4",
         "express": "*",
         "glob": "*"
       },
@@ -20,8 +19,14 @@
         "@babel/core": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
         "@babel/register": "^7.0.0",
+        "ansi-regex": "5.0.1",
+        "ansi-styles": "3.2.1",
         "chai": "*",
         "chai-http": "*",
+        "chalk": "2.4.2",
+        "color-convert": "1.9.3",
+        "color-name": "1.1.3",
+        "debug": "4.4.0",
         "eslint": "^7.32.0",
         "eslint-config-standard": "^16.0.3",
         "eslint-plugin-chai-friendly": "^0.7.2",
@@ -33,7 +38,11 @@
         "fancy-log": "^1.3.3",
         "mocha": "*",
         "nodemon": "*",
-        "prettier": "^2.4.1"
+        "prettier": "^2.4.1",
+        "slice-ansi": "4.0.0",
+        "strip-ansi": "6.0.1",
+        "supports-color": "5.5.0",
+        "wrap-ansi": "8.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2082,6 +2091,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2091,6 +2101,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2558,6 +2569,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2725,6 +2737,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -2733,7 +2746,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -2859,6 +2873,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6365,6 +6380,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -6557,6 +6573,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6669,6 +6686,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "ajv": "^8.11.0",
     "axios": "*",
-    "debug": "^4.3.4",
     "express": "*",
     "glob": "*"
   },
@@ -43,8 +42,14 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "ansi-regex": "5.0.1",
+    "ansi-styles": "3.2.1",
     "chai": "*",
     "chai-http": "*",
+    "chalk": "2.4.2",
+    "color-convert": "1.9.3",
+    "color-name": "1.1.3",
+    "debug": "4.4.0",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-chai-friendly": "^0.7.2",
@@ -56,7 +61,11 @@
     "fancy-log": "^1.3.3",
     "mocha": "*",
     "nodemon": "*",
-    "prettier": "^2.4.1"
+    "prettier": "^2.4.1",
+    "slice-ansi": "4.0.0",
+    "strip-ansi": "6.0.1",
+    "supports-color": "5.5.0",
+    "wrap-ansi": "8.1.0"
   },
   "prettier": {}
 }


### PR DESCRIPTION
### What is the context of this PR?
Starting September 8th 13:16 UTC it has been reported that the npm debug and chalk packages were compromised.
This PR is to pin any packages related to the compromised packages to prevent any upgrades to the compromised versions.

Packages Pinned
ansi-regex
ansi-styles
chalk
color-convert
color-name
debug
error-ex
strip-ansi
supports-color
wrap-ansi


### How to review
Describe the steps required to test the changes (include screenshots if appropriate).

### Checklist
* [ ] eq-translations updated to support any new schema keys which need translation
