### PR TITLE
Manual package updates

### DIFF
--- a/ajv/app.js
+++ b/ajv/app.js
@@ -11,7 +11,7 @@ const AJV_VALIDATOR_PORT = process.env.AJV_VALIDATOR_PORT || 5002;
 app.use(
   express.json({
     limit: "2Mb",
-  })
+  }),
 );
 
 // Only start the server if we're not in a test environment, otherwise export the app for testing purposes

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "ajv": "8.18.0",
-        "axios": "1.13.6",
+        "axios": "1.15.0",
         "debug": "4.4.3",
         "express": "5.2.1",
         "glob": "13.0.6"
@@ -22,14 +22,14 @@
         "@babel/register": "7.28.6",
         "@eslint/json": "^1.2.0",
         "eslint": "^9.39.3",
-        "eslint-plugin-chai-friendly": "1.1.1",
+        "eslint-plugin-chai-friendly": "1.2.0",
         "eslint-plugin-security": "4.0.0",
         "globals": "^17.4.0",
         "jest": "^30.3.0",
         "jsonc-eslint-parser": "^3.1.0",
         "neostandard": "^0.13.0",
         "nodemon": "3.1.14",
-        "prettier": "2.8.8",
+        "prettier": "3.8.1",
         "supertest": "^7.2.2"
       }
     },
@@ -4131,14 +4131,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5374,9 +5374,9 @@
       }
     },
     "node_modules/eslint-plugin-chai-friendly": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.1.1.tgz",
-      "integrity": "sha512-HdWGqTQAv4GLNWkSRen3mNnhFBFlovEGuyZKxdcuZnoQjcyhN8WmS3PGYOEHsqY5PTQ4EtyPaoarKO3hQISn6g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.2.0.tgz",
+      "integrity": "sha512-um2pBb4ZXNCoTRPRAWiUaXeIaw1dRaPOEZ+G/qcZqfyTdkCXXwOBctnfnbIRbZiQf4AXl3ImV1grt423SlK+mg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9362,16 +9362,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -9438,10 +9438,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/ONSdigital/eq-schema-validator#readme",
   "dependencies": {
     "ajv": "8.18.0",
-    "axios": "1.13.6",
+    "axios": "1.15.0",
     "debug": "4.4.3",
     "express": "5.2.1",
     "glob": "13.0.6"
@@ -45,13 +45,13 @@
     "@babel/register": "7.28.6",
     "@eslint/json": "^1.2.0",
     "eslint": "^9.39.3",
-    "eslint-plugin-chai-friendly": "1.1.1",
+    "eslint-plugin-chai-friendly": "1.2.0",
     "eslint-plugin-security": "4.0.0",
     "globals": "^17.4.0",
     "jsonc-eslint-parser": "^3.1.0",
     "neostandard": "^0.13.0",
     "nodemon": "3.1.14",
-    "prettier": "2.8.8",
+    "prettier": "3.8.1",
     "jest": "^30.3.0",
     "supertest": "^7.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "^9.39.3",
     "eslint-plugin-chai-friendly": "1.2.0",
     "eslint-plugin-security": "4.0.0",
-    "globals": "^17.4.0",
+    "globals": "^17.5.0",
     "jsonc-eslint-parser": "^3.1.0",
     "neostandard": "^0.13.0",
     "nodemon": "3.1.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,13 @@ indent-style = "space"
 
 [tool.pyright]
 reportMissingImports = false
+
+[tool.flake8]
+max-complexity = 10
+exclude = [
+    ".venv",
+    ".tox",
+    "node_modules",
+    "htmlcov",
+    "megalinter-reports"
+]

--- a/scripts/run_lint_python.sh
+++ b/scripts/run_lint_python.sh
@@ -18,22 +18,31 @@ function display_result {
     fi
 }
 
-flake8 --max-complexity 10 --count
+COMMON_EXCLUDES=".venv,.tox,node_modules,htmlcov,megalinter-reports"
+BLACK_EXCLUDES='/(\.venv|\.tox|node_modules|htmlcov|megalinter-reports)/'
+
+flake8 --max-complexity 10 --count --exclude "$COMMON_EXCLUDES"
 display_result $? 1 "Flake 8 code style check"
 
-find . -type f -name "*.py" | xargs pylint --reports=n --output-format=colorized --rcfile=.pylintrc -j 0
+find . \
+    \( -path "./.venv" -o \
+    -path "./.tox" -o \
+    -path "./node_modules" -o \
+    -path "./htmlcov" -o \
+    -path "./megalinter-reports" \) -prune \
+    -o -type f -name "*.py" -print | xargs pylint --reports=n --output-format=colorized --rcfile=.pylintrc -j 0
 # pylint bit encodes the exit code to allow you to figure out which category has failed.
 # https://docs.pylint.org/en/1.6.0/run.html#exit-codes
 # We want to fail on all errors so don't check for specific bits in the output; but if we did in future, see:
 # http://stackoverflow.com/questions/6626351/how-to-extract-bits-from-return-code-number-in-bash
 display_result $? 2 "Pylint linting check"
 
-isort --check .
+isort --check --skip .venv --skip .tox --skip node_modules --skip htmlcov --skip megalinter-reports .
 display_result $? 1 "isort linting check"
 
-black --check . --exclude node_modules
+black --check . --exclude "$BLACK_EXCLUDES"
 
 display_result $? 1 "Python code formatting check"
 
-ruff check .
+ruff check . --exclude .venv --exclude .tox --exclude node_modules --exclude htmlcov --exclude megalinter-reports
 display_result $? 1 "Ruff linting check"

--- a/scripts/run_lint_python.sh
+++ b/scripts/run_lint_python.sh
@@ -18,10 +18,7 @@ function display_result {
     fi
 }
 
-COMMON_EXCLUDES=".venv,.tox,node_modules,htmlcov,megalinter-reports"
-BLACK_EXCLUDES='/(\.venv|\.tox|node_modules|htmlcov|megalinter-reports)/'
-
-flake8 --max-complexity 10 --count --exclude "$COMMON_EXCLUDES"
+flake8 --count
 display_result $? 1 "Flake 8 code style check"
 
 find . \
@@ -37,12 +34,12 @@ find . \
 # http://stackoverflow.com/questions/6626351/how-to-extract-bits-from-return-code-number-in-bash
 display_result $? 2 "Pylint linting check"
 
-isort --check --skip .venv --skip .tox --skip node_modules --skip htmlcov --skip megalinter-reports .
+isort --check .
 display_result $? 1 "isort linting check"
 
-black --check . --exclude "$BLACK_EXCLUDES"
+black --check .
 
 display_result $? 1 "Python code formatting check"
 
-ruff check . --exclude .venv --exclude .tox --exclude node_modules --exclude htmlcov --exclude megalinter-reports
+ruff check .
 display_result $? 1 "Ruff linting check"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [flake8]
 # Ignore node_modules and cloned repos when not in a virtual environment
-exclude = node_modules/*,tests/*,src/*
+exclude = .venv/*,.tox/*,htmlcov/*,megalinter-reports/*,node_modules/*,tests/*,src/*
 max-line-length = 160
 ignore = C815,C816,W503,E203
 inline-quotes = double


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

### Motivation and Context

Manual update of updatable npm packages

### What has changed

Bump eslint-plugin-chai-friendly to 1.2.0
Bump prettier to 3.8.1
Bump Globals to 17.5.0
Tweaks to tox.ini and run_lint_python to prevent local checks of package files

### How to test?

Check tests pass etc
